### PR TITLE
enhancement: include styled-component styles to ssr

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,9 @@
         "next/babel"
     ],
     "plugins": [
-        "babel-plugin-styled-components"
+        [
+            "styled-components",
+            {"ssr": true, "displayName": true}
+        ]
     ]
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,10 +5,12 @@ import { theme } from '../styles/theme';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider theme={theme}>
+    <>
       <GlobalStyle />
-      <Component {...pageProps} />
-    </ThemeProvider>
+      <ThemeProvider theme={theme}>
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </>
   );
 }
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,11 +5,30 @@ import Document, {
   NextScript,
   DocumentContext,
 } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
-    const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+    try {
+      ctx.renderPage = () => originalRenderPage({
+        enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+      });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
   }
 
   render() {


### PR DESCRIPTION
styled-component가 build 과정에서 css style sheet를 생성하지 않고 js로 동작하는 문제로 인해, 첫 로딩시 스타일이 없는 화면이 발생하는 문제 해결. 

이제 styled-component 에 적용된 스타일 들이 페이지에 css style sheet 로 직접 포함됨. 