### PR TITLE
fix: Fix job avatar opacity

### DIFF
--- a/components/StoryBox.tsx
+++ b/components/StoryBox.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 import {
-  Designer, Programmer, GreenQuote1, GreenQuote2, BlueQuote1, BlueQuote2,
+  GreenQuote1, GreenQuote2, BlueQuote1, BlueQuote2,
 } from '../public';
 
 const StoryBox = ({ story }) => (
   <Container>
-    {story.job === 'programmer' && <Programmer />}
+    {story.job === 'programmer' && <JobAvatar job={story.job} />}
     <Bubble job={story.job}>
       <div className="quote1">{story.job === 'programmer' ? <GreenQuote1 /> : <BlueQuote1 />}</div>
       <div className="quote2">{story.job === 'programmer' ? <GreenQuote2 /> : <BlueQuote2 />}</div>
@@ -13,8 +13,15 @@ const StoryBox = ({ story }) => (
         <div className="content__person">{story.person}</div>
       </div>
     </Bubble>
-    {story.job === 'designer' && <Designer />}
+    {story.job === 'designer' && <JobAvatar job={story.job} />}
   </Container>
+);
+
+const JobAvatar = ({ job }) => (
+  <img
+    src={job === 'designer' ? '/Group 290.svg' : '/Group 289.svg'}
+    alt="Job Avatar"
+  />
 );
 
 const Container = styled.div`


### PR DESCRIPTION
이유는 모르겠지만, svg 이미지 리소스를 리소스 `import` 형태로 사용하면 투명도가 높아짐. 
`Image` 컴포넌트나 `img` 태그를 사용하면 멀쩡함. `Image` 컴포넌트는 서버 기능이 필요하므로 비용을 없애기 위해 `img` 태그로 전부 대체함. 