### PR TITLE
모집 시작 날짜 표기 방법 수정

### DIFF
--- a/modules/about/components/Section1/Section1.tsx
+++ b/modules/about/components/Section1/Section1.tsx
@@ -18,7 +18,7 @@ export default function Section1() {
         <Title device={device}>
           DEPROMEET
           <br />
-          2022.08.22
+          2022. 08. 22.
         </Title>
         <Subtitle device={device}>
           디프만 12기 멤버 모집이 시작됩니다.


### PR DESCRIPTION
국립 국어원을 참고하여 `2022.08.22`을 `2022. 08. 22.`로 수정했습니다.

report by @junhaesung 🙇 