### PR TITLE
Build warning 해결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,3 @@
-const withPlugins = require('next-compose-plugins');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
@@ -14,4 +13,12 @@ const nextConfig = {
   },
 };
 
-module.exports = withPlugins([withBundleAnalyzer], nextConfig);
+/**
+ *
+ * @link https://github.com/cyrilwanner/next-compose-plugins/issues/59#issuecomment-1209152211
+ * warnning 해결 입니다. "next-compose-plugins"의 이슈로 defaultConfig를 모두 정의해줘야되는 wanning이 떠서 시원하게 없앴습니다.
+ */
+module.exports = () => {
+  const plugins = [withBundleAnalyzer];
+  return plugins.reduce((acc, plugin) => plugin(acc), { ...nextConfig });
+};

--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,6 @@ const nextConfig = {
 /**
  *
  * @link https://github.com/cyrilwanner/next-compose-plugins/issues/59#issuecomment-1209152211
- * warnning 해결 입니다. "next-compose-plugins"의 이슈로 defaultConfig를 모두 정의해줘야되는 wanning이 떠서 시원하게 없앴습니다.
  */
 module.exports = () => {
   const plugins = [withBundleAnalyzer];


### PR DESCRIPTION
- `Invalid next.config.js options detected` 발생 warning 해결
  - `next-compose-plugins` 관련 이슈로 next.js issue쪽에서도 많이 올라오고 있더라구요!
  - [링크1](https://github.com/cyrilwanner/next-compose-plugins/issues/59#issuecomment-1209152211) [링크2](https://github.com/vercel/next.js/issues/39606) 참조해서 해결했습니다.
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/59507527/184952002-db11e685-d633-4839-ac85-70f2bd36d361.png">
