### PR TITLE
분석 도구 부착

### DIFF
--- a/src/constants/common/common.ts
+++ b/src/constants/common/common.ts
@@ -1,1 +1,4 @@
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
+export const GA_ID = 'G-VZ0Q43XDPN';
+export const HOTJAR_ID = '3115834';

--- a/src/constants/common/index.ts
+++ b/src/constants/common/index.ts
@@ -1,2 +1,2 @@
-export { IS_PRODUCTION } from './common';
+export { GA_ID, HOTJAR_ID, IS_PRODUCTION } from './common';
 export { DEPROMEET_MEDIUM } from './depromeet';

--- a/src/hooks/use-record-pageview/index.ts
+++ b/src/hooks/use-record-pageview/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-record-pageview';

--- a/src/hooks/use-record-pageview/use-record-pageview.ts
+++ b/src/hooks/use-record-pageview/use-record-pageview.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+import { GA_ID, IS_PRODUCTION } from '~/constants/common';
+
+export default function useRecordPageview() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const recordPageview = (url: string) => {
+      gaPageview(url);
+    };
+
+    if (IS_PRODUCTION) router.events.on('routeChangeComplete', recordPageview);
+    return () => {
+      if (IS_PRODUCTION) router.events.off('routeChangeComplete', recordPageview);
+    };
+  }, [router.events]);
+}
+
+declare global {
+  interface Window {
+    gtag: (param1: string, param2: string | undefined, param3: object) => void;
+  }
+}
+
+function gaPageview(url: string) {
+  if (typeof window.gtag === 'undefined') return;
+  window.gtag('config', GA_ID, { page_path: url });
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,10 +3,13 @@ import { css } from '@emotion/react';
 
 import Footer from '~/components/common/Footer';
 import NavigationBar from '~/components/common/NavigationBar';
+import useRecordPageview from '~/hooks/use-record-pageview';
 import { layoutCss } from '~/styles/css';
 import GlobalStyle from '~/styles/GlobalStyle';
 
 export default function App({ Component, pageProps }: AppProps) {
+  useRecordPageview();
+
   return (
     <>
       <GlobalStyle />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,6 @@
 import { Head, Html, Main, NextScript } from 'next/document';
 
-import { IS_PRODUCTION } from '~/constants/common';
+import { GA_ID, HOTJAR_ID, IS_PRODUCTION } from '~/constants/common';
 
 export default function Document() {
   return (
@@ -68,6 +68,3 @@ export default function Document() {
     </Html>
   );
 }
-
-const GA_ID = 'G-VZ0Q43XDPN';
-const HOTJAR_ID = '3115834';

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,7 @@
 import { Head, Html, Main, NextScript } from 'next/document';
 
+import { IS_PRODUCTION } from '~/constants/common';
+
 export default function Document() {
   return (
     <Html lang="kr">
@@ -29,7 +31,7 @@ export default function Document() {
         <meta name="twitter:image" content={IMAGE} /> */}
 
         {/* for google analytics */}
-        {/* {IS_PRODUCTION && (
+        {IS_PRODUCTION && (
           <>
             <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
             <script
@@ -41,8 +43,22 @@ export default function Document() {
               gtag('config', '${GA_ID}');`,
               }}
             />
+
+            {/* hotjar */}
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `(function(h,o,t,j,a,r){
+              h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+              h._hjSettings={hjid:${HOTJAR_ID},hjsv:6};
+              a=o.getElementsByTagName('head')[0];
+              r=o.createElement('script');r.async=1;
+              r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+              a.appendChild(r);
+          })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');`,
+              }}
+            ></script>
           </>
-        )} */}
+        )}
       </Head>
 
       <body>
@@ -52,3 +68,6 @@ export default function Document() {
     </Html>
   );
 }
+
+const GA_ID = 'G-VZ0Q43XDPN';
+const HOTJAR_ID = '3115834';


### PR DESCRIPTION
- `GA`와 `Hotjar`를 부착했어요

- GA 페이지 뷰를 기록하기 위한 `use-record-pageview` 훅을 개발, 적용했어요