### PR TITLE
home route 모바일 대응

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,7 +1,7 @@
 import { ComponentPropsWithoutRef, forwardRef, Ref } from 'react';
 import { css } from '@emotion/react';
 
-import { colors, radius } from '~/styles/constants';
+import { colors, mediaQuery, radius } from '~/styles/constants';
 
 interface Props extends ComponentPropsWithoutRef<'button'> {
   isActive?: boolean;
@@ -38,6 +38,13 @@ const buttonCss = (isActive: boolean) => css`
   }
 
   ${isActive && activeCss}
+
+  ${mediaQuery('xs')} {
+    white-space: pre;
+
+    padding: 8px 16px;
+    font-size: 14px;
+  }
 `;
 
 const activeCss = css`

--- a/src/components/common/CTAButton/CTAButton.tsx
+++ b/src/components/common/CTAButton/CTAButton.tsx
@@ -1,7 +1,7 @@
 import { ComponentPropsWithoutRef, forwardRef, Ref } from 'react';
 import { css } from '@emotion/react';
 
-import { colors, radius } from '~/styles/constants';
+import { colors, mediaQuery, radius } from '~/styles/constants';
 
 interface Props extends ComponentPropsWithoutRef<'button'> {}
 
@@ -30,5 +30,10 @@ const buttonCss = css`
 
   &:hover {
     background-color: ${colors.primaryDark};
+  }
+
+  ${mediaQuery('xs')} {
+    padding: 16px 30px;
+    font-size: 16px;
   }
 `;

--- a/src/components/home/ApplySection/ApplySection.tsx
+++ b/src/components/home/ApplySection/ApplySection.tsx
@@ -8,7 +8,7 @@ import {
   defaultFadeInVariants,
   staggerHalf,
 } from '~/constants/motions';
-import { colors } from '~/styles/constants';
+import { colors, mediaQuery } from '~/styles/constants';
 
 export default function ApplySection() {
   return (
@@ -58,6 +58,13 @@ const spanCss = css`
   text-align: center;
 
   margin-bottom: 12px;
+
+  ${mediaQuery('xs')} {
+    font-size: 16px;
+    line-height: 150%;
+
+    margin-bottom: 8px;
+  }
 `;
 
 const headingCss = css`
@@ -68,4 +75,11 @@ const headingCss = css`
   text-align: center;
 
   margin-bottom: 60px;
+
+  ${mediaQuery('xs')} {
+    font-size: 24px;
+    line-height: 150%;
+
+    margin-bottom: 30px;
+  }
 `;

--- a/src/components/home/MoreInfoSection/MoreInfoSection.tsx
+++ b/src/components/home/MoreInfoSection/MoreInfoSection.tsx
@@ -4,16 +4,19 @@ import { motion } from 'framer-motion';
 
 import { DEPROMEET_MEDIUM } from '~/constants/common';
 import { defaultFadeInUpVariants, defaultFadeInVariants, staggerOne } from '~/constants/motions';
-import { colors, radius } from '~/styles/constants';
+import useMediaQuery from '~/hooks/use-media-query';
+import { colors, mediaQuery, radius } from '~/styles/constants';
 
 export default function MoreInfoSection() {
+  const isMobile = useMediaQuery('xs');
+
   return (
     <motion.section
       css={sectionCss}
       initial="initial"
       whileInView="animate"
       exit="exit"
-      viewport={{ amount: 0.6, once: true }}
+      viewport={{ amount: isMobile ? 0.2 : 0.6, once: true }}
     >
       <motion.h2 css={headingCss} variants={defaultFadeInVariants}>
         디프만에 대해서
@@ -51,6 +54,13 @@ const headingCss = css`
   line-height: 150%;
 
   margin-bottom: 50px;
+
+  ${mediaQuery('xs')} {
+    font-size: 24px;
+    font-weight: 500;
+
+    margin-bottom: 30px;
+  }
 `;
 
 const articleWrapperCss = css`
@@ -58,6 +68,11 @@ const articleWrapperCss = css`
   display: flex;
   justify-content: space-evenly;
   gap: 2.625rem;
+
+  ${mediaQuery('xs')} {
+    flex-direction: column;
+    gap: 15px;
+  }
 `;
 
 interface LinkArticleProps {
@@ -93,16 +108,28 @@ const anchorCss = css`
   overflow: hidden;
   border-radius: ${radius.md};
   background-color: ${colors.gray9};
+
+  ${mediaQuery('xs')} {
+    height: 354px;
+  }
 `;
 
 const imageWrapperCss = css`
   width: 100%;
   height: 346px;
   background-color: ${colors.gray7};
+
+  ${mediaQuery('xs')} {
+    height: 233px;
+  }
 `;
 
 const contentWrapperCss = css`
   padding: 35px 2.5rem;
+
+  ${mediaQuery('xs')} {
+    padding: 20px;
+  }
 `;
 
 const contentHeadingCss = css`
@@ -112,6 +139,12 @@ const contentHeadingCss = css`
   line-height: 120%;
 
   margin-bottom: 12px;
+
+  ${mediaQuery('xs')} {
+    font-size: 14px;
+
+    margin-bottom: 6px;
+  }
 `;
 
 const contentParagraphCss = css`
@@ -119,4 +152,9 @@ const contentParagraphCss = css`
   font-size: 1.625rem;
   font-weight: 600;
   line-height: 150%;
+
+  ${mediaQuery('xs')} {
+    width: 60%;
+    font-size: 18px;
+  }
 `;

--- a/src/components/home/RecordSection/RecordSection.tsx
+++ b/src/components/home/RecordSection/RecordSection.tsx
@@ -56,11 +56,13 @@ const headingCss = css`
 
 const cardWrapperCss = css`
   margin-top: 60px;
+
   width: 100%;
   display: flex;
   justify-content: space-evenly;
 
   ${mediaQuery('xs')} {
+    margin-top: 40px;
     gap: 15px;
     flex-wrap: wrap;
   }

--- a/src/components/home/RecordSection/RecordSection.tsx
+++ b/src/components/home/RecordSection/RecordSection.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
 import { defaultFadeInUpVariants, defaultFadeInVariants, staggerOne } from '~/constants/motions';
-import { colors, radius } from '~/styles/constants';
+import { colors, mediaQuery, radius } from '~/styles/constants';
 
 const RECORDS: CardProps[] = [
   { title: '탄생한지', value: '6년' },
@@ -47,6 +47,11 @@ const headingCss = css`
   text-align: center;
   font-size: 2.75rem;
   line-height: 150%;
+
+  ${mediaQuery('xs')} {
+    font-size: 24px;
+    font-weight: 500;
+  }
 `;
 
 const cardWrapperCss = css`
@@ -54,6 +59,11 @@ const cardWrapperCss = css`
   width: 100%;
   display: flex;
   justify-content: space-evenly;
+
+  ${mediaQuery('xs')} {
+    gap: 15px;
+    flex-wrap: wrap;
+  }
 `;
 
 interface CardProps {
@@ -83,6 +93,12 @@ const cardCss = css`
 
   width: 23%;
   height: 255px;
+
+  ${mediaQuery('xs')} {
+    width: calc(50% - 7.5px);
+    aspect-ratio: 1 / 1;
+    height: auto;
+  }
 `;
 
 const titleCss = css`
@@ -90,12 +106,20 @@ const titleCss = css`
   font-size: 1.5rem;
   line-height: 112.5%;
   margin-bottom: 12px;
+
+  ${mediaQuery('xs')} {
+    font-size: 14px;
+  }
 `;
 
 const valueCss = css`
   font-size: 3.125rem;
   line-height: 112.5%;
   font-weight: 700;
+
+  ${mediaQuery('xs')} {
+    font-size: 30px;
+  }
 `;
 
 const descriptionCss = css`
@@ -103,4 +127,8 @@ const descriptionCss = css`
   bottom: 20px;
   color: ${colors.gray6};
   font-size: 1.125rem;
+
+  ${mediaQuery('xs')} {
+    font-size: 12px;
+  }
 `;

--- a/src/components/home/ScheduleSection/ScheduleSection.tsx
+++ b/src/components/home/ScheduleSection/ScheduleSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 
 import { defaultFadeInVariants, staggerHalf } from '~/constants/motions';
 import { defaultFadeInSlideToRightVariants, staggerOne } from '~/constants/motions/motions';
-import { colors, radius } from '~/styles/constants';
+import { colors, mediaQuery, radius } from '~/styles/constants';
 
 interface Scehdule {
   week: string;
@@ -73,6 +73,13 @@ const headingCss = css`
   line-height: 150%;
 
   margin-bottom: 10px;
+
+  ${mediaQuery('xs')} {
+    font-size: 24px;
+    font-weight: 500;
+
+    margin-bottom: 8px;
+  }
 `;
 
 const descriptionCss = css`
@@ -82,12 +89,22 @@ const descriptionCss = css`
   line-height: 140%;
 
   margin-bottom: 50px;
+
+  ${mediaQuery('xs')} {
+    font-size: 14px;
+
+    margin-bottom: 30px;
+  }
 `;
 
 const articleWrapperCss = css`
   display: flex;
   flex-direction: column;
   gap: 30px;
+
+  ${mediaQuery('xs')} {
+    gap: 14px;
+  }
 `;
 
 const articleCss = css`
@@ -99,6 +116,10 @@ const articleCss = css`
   padding: 40px;
 
   overflow: hidden;
+
+  ${mediaQuery('xs')} {
+    padding: 20px;
+  }
 `;
 
 const articleWeekCss = css`
@@ -107,6 +128,12 @@ const articleWeekCss = css`
   font-size: 1.25rem;
 
   margin-bottom: 12px;
+
+  ${mediaQuery('xs')} {
+    font-size: 14px;
+
+    margin-bottom: 6px;
+  }
 `;
 
 const articleTitleCss = css`
@@ -114,6 +141,12 @@ const articleTitleCss = css`
   font-size: 1.5rem;
   line-height: 150%;
   width: 50%;
+
+  ${mediaQuery('xs')} {
+    font-size: 16px;
+    font-weight: 500;
+    width: 100%;
+  }
 `;
 
 const articleImageWrapperCss = css`
@@ -124,4 +157,13 @@ const articleImageWrapperCss = css`
   width: 378px;
   height: 100%;
   background-color: ${colors.gray8};
+
+  ${mediaQuery('xs')} {
+    top: unset;
+    bottom: 20px;
+    right: 20px;
+
+    width: 70px;
+    height: 70px;
+  }
 `;

--- a/src/components/home/TeamSection/TeamSection.tsx
+++ b/src/components/home/TeamSection/TeamSection.tsx
@@ -10,7 +10,7 @@ import {
   staggerHalf,
   staggerOne,
 } from '~/constants/motions';
-import { colors, radius } from '~/styles/constants';
+import { colors, mediaQuery, radius } from '~/styles/constants';
 
 const TEAMS = ['UIUX DESIGN', 'iOS', 'Android', 'Web', 'Backend'] as const;
 
@@ -111,6 +111,13 @@ const headingCss = css`
   line-height: 150%;
 
   margin-bottom: 60px;
+
+  ${mediaQuery('xs')} {
+    font-size: 24px;
+    font-weight: 500;
+
+    margin-bottom: 30px;
+  }
 `;
 
 const buttonWrapperCss = css`
@@ -120,6 +127,14 @@ const buttonWrapperCss = css`
   gap: 1.875rem;
 
   margin-bottom: 40px;
+
+  ${mediaQuery('xs')} {
+    overflow-x: scroll;
+    justify-content: flex-start;
+    gap: 14px;
+
+    margin-bottom: 24px;
+  }
 `;
 
 const contentWrapperCss = css`
@@ -131,6 +146,12 @@ const contentWrapperCss = css`
 
   display: flex;
   gap: 5rem;
+
+  ${mediaQuery('xs')} {
+    flex-direction: column;
+    padding: 30px 20px;
+    gap: 30px;
+  }
 `;
 
 const contentImageWrapperCss = css`
@@ -138,6 +159,13 @@ const contentImageWrapperCss = css`
   height: 100%;
   background-color: gray;
   flex-shrink: 0;
+
+  ${mediaQuery('xs')} {
+    flex-direction: column;
+    align-self: center;
+    width: 120px;
+    height: 120px;
+  }
 `;
 
 const contentHeadingCss = css`
@@ -146,12 +174,21 @@ const contentHeadingCss = css`
   font-weight: 700;
   line-height: 150%;
   margin-bottom: 10px;
+
+  ${mediaQuery('xs')} {
+    font-size: 18px;
+    text-align: center;
+  }
 `;
 
 const contentParagraphCss = css`
   color: ${colors.gray4};
   font-size: 1.375rem;
   line-height: 150%;
+
+  ${mediaQuery('xs')} {
+    font-size: 14px;
+  }
 `;
 
 const cardSwitchVariants: Variants = {

--- a/src/hooks/use-media-query/index.ts
+++ b/src/hooks/use-media-query/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-media-query';

--- a/src/hooks/use-media-query/use-media-query.ts
+++ b/src/hooks/use-media-query/use-media-query.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+import { size, SizeKey } from '~/styles/constants';
+
+export function useMediaQuery(width: number): boolean;
+
+export function useMediaQuery(sizeKey: SizeKey): boolean;
+
+export default function useMediaQuery(width: number | SizeKey) {
+  const [targetReached, setTargetReached] = useState(false);
+
+  useEffect(() => {
+    function updateTarget(e: MediaQueryListEvent) {
+      setTargetReached(e.matches);
+    }
+
+    const targetWidth = typeof width === 'number' ? `${width}px` : size[width];
+
+    const media = window.matchMedia(`(max-width: ${targetWidth})`);
+    media.addListener(updateTarget);
+
+    if (media.matches) {
+      setTargetReached(true);
+    }
+
+    return () => media.removeListener(updateTarget);
+  }, [width]);
+
+  return targetReached;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,4 +26,5 @@ export default function App({ Component, pageProps }: AppProps) {
 const contentLayoutCss = css`
   ${layoutCss}
   padding-top: 60px; // NOTE: NavigationBar 높이
+  overflow-x: hidden;
 `;

--- a/src/styles/constants/media.ts
+++ b/src/styles/constants/media.ts
@@ -6,7 +6,7 @@ export const size = {
   xl: '1920px',
 } as const;
 
-type SizeKey = keyof typeof size;
+export type SizeKey = keyof typeof size;
 
 export function mediaQuery(maxWidth: number): string;
 


### PR DESCRIPTION
- root route의 섹션들을 모바일 대응했어요

- `use-media-query`를 개발했어요

  - 사용 방법

```tsx
const isMobile = useMediaQuery('xs');

const isMobile = useMediaQuery(1000);
```
