### PR TITLE
Navigation bar 상수 적용

### DIFF
--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -60,13 +60,15 @@ export default function NavigationBar() {
   );
 }
 
+export const NAV_HEIGHT = 60;
+
 const navCss = css`
   position: fixed;
   top: 0;
   left: 0;
 
   width: 100%;
-  height: 60px;
+  height: ${NAV_HEIGHT}px;
   background-color: ${colors.black};
   z-index: 9999;
 `;

--- a/src/components/home/HeaderSection/HeaderSection.tsx
+++ b/src/components/home/HeaderSection/HeaderSection.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { motion, useScroll, useTransform, Variants } from 'framer-motion';
 
 import { ScrollBottomIcon } from '~/components/common/icons';
+import { NAV_HEIGHT } from '~/components/common/NavigationBar/NavigationBar';
 import { defaultEasing } from '~/constants/motions';
 
 export default function HeaderSection() {
@@ -30,7 +31,7 @@ export default function HeaderSection() {
 const headerCss = css`
   position: relative;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - ${NAV_HEIGHT}px);
 `;
 
 const scrollBottomIconWrapperCss = css`

--- a/src/components/interview/InterviewSection/InterviewSection.tsx
+++ b/src/components/interview/InterviewSection/InterviewSection.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import Button from '~/components/common/Button';
+import { NAV_HEIGHT } from '~/components/common/NavigationBar/NavigationBar';
 import { defaultFadeInScaleVariants, staggerHalf } from '~/constants/motions';
 import {
   defaultFadeInSlideToRightVariants,
@@ -86,7 +87,7 @@ const buttonWrapperCss = css`
     margin-bottom: 40px;
 
     position: sticky;
-    top: 60px; // NOTE: nav 높이
+    top: ${NAV_HEIGHT}px;
     z-index: 1000;
   }
 `;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/react';
 
 import Footer from '~/components/common/Footer';
 import NavigationBar from '~/components/common/NavigationBar';
+import { NAV_HEIGHT } from '~/components/common/NavigationBar/NavigationBar';
 import { BASE_URL } from '~/constants/common';
 import useRecordPageview from '~/hooks/use-record-pageview';
 import { layoutCss } from '~/styles/css';
@@ -36,5 +37,5 @@ export default function App({ Component, pageProps }: AppProps) {
 
 const contentLayoutCss = css`
   ${layoutCss}
-  padding-top: 60px; // NOTE: NavigationBar 높이
+  padding-top: ${NAV_HEIGHT}px;
 `;


### PR DESCRIPTION
- 국지적으로 코멘트에 의존해 사용되던 네브바의 높이를 상수로써 모듈화 하였습니다
- `/`의 `HeaderSection`에서 네브바 높이를 계산하지 않아 잘리던 부분을 수정했습니다