### PR TITLE
모바일 네비게이션 높이 적용이 겹침 해결

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -37,5 +37,5 @@ export default function App({ Component, pageProps }: AppProps) {
 
 const contentLayoutCss = css`
   ${layoutCss}
-  padding-top: ${NAV_HEIGHT}px;
+  margin-top: ${NAV_HEIGHT}px;
 `;


### PR DESCRIPTION
- 모바일일 경우 mediaQuery로 정의된 것으로 padding-top: 0 으로 덮어 써 짐으로 높이관련 이슈가 있었습니다. (사진 1, 사진 2참조)
  - 해당사항을 margin-top으로 변경해서 해결 했습니다.
  
### 사진 1
<img width="472" alt="image" src="https://user-images.githubusercontent.com/59507527/185759142-f907f33e-2657-48f9-b8a3-81e3ecd2cf8e.png">

### 사진 2
<img width="472" alt="image" src="https://user-images.githubusercontent.com/59507527/185759169-b4e76b9b-c4eb-4e56-880e-f77777e9ac47.png">

### 사진 3 (해결)
<img width="472" alt="image" src="https://user-images.githubusercontent.com/59507527/185759188-75fa56bc-ca8b-42d3-b42d-8c889268398e.png">
