### PR TITLE
SEO 컴포넌트 적용

### DIFF
--- a/src/components/interview/HeaderSection/HeaderSection.tsx
+++ b/src/components/interview/HeaderSection/HeaderSection.tsx
@@ -32,7 +32,6 @@ const headerCss = css`
   width: 100vw;
   left: calc(-50vw + 50%);
   height: 400px;
-  background-color: gray;
 
   ${mediaQuery('xs')} {
     height: 200px;

--- a/src/pages/project/[order].tsx
+++ b/src/pages/project/[order].tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
+import SEO from '~/components/common/SEO';
 import AnotherProjectSection from '~/components/project/AnotherProjectSection';
 import { Project, projects } from '~/components/project/constants';
 import ProjectDetailSection from '~/components/project/ProjectDetailSection';
@@ -35,10 +36,13 @@ export default function ProjectDetail() {
   }
 
   return (
-    <main>
-      <ProjectDetailSection project={project} />
-      <AnotherProjectSection />
-    </main>
+    <>
+      <SEO title={`디프만 - ${project.title}`} />
+      <main>
+        <ProjectDetailSection project={project} />
+        <AnotherProjectSection />
+      </main>
+    </>
   );
 }
 

--- a/src/pages/project/index.tsx
+++ b/src/pages/project/index.tsx
@@ -1,13 +1,17 @@
+import SEO from '~/components/common/SEO';
 import DescriptionSection from '~/components/project/DescriptionSection';
 import HorizontalDivider from '~/components/project/HorizontalDivider';
 import ProjectSection from '~/components/project/ProjectSection';
 
 export default function Project() {
   return (
-    <main>
-      <DescriptionSection />
-      <HorizontalDivider />
-      <ProjectSection />
-    </main>
+    <>
+      <SEO title="디프만 - Project" />
+      <main>
+        <DescriptionSection />
+        <HorizontalDivider />
+        <ProjectSection />
+      </main>
+    </>
   );
 }

--- a/src/pages/recruit/[position]/index.tsx
+++ b/src/pages/recruit/[position]/index.tsx
@@ -2,6 +2,7 @@ import Error from 'next/error';
 import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 
+import SEO from '~/components/common/SEO';
 import { POSITION_TYPE, PositionType } from '~/components/recruit-detail/constants';
 import DescriptionSection from '~/components/recruit-detail/DescriptionSection';
 import HeaderSection from '~/components/recruit-detail/HeaderSection';
@@ -15,10 +16,13 @@ export default function RecruitDetail() {
   if (!position && !positionType) return <Error statusCode={404} />;
 
   return (
-    <main>
-      <HeaderSection positionType={positionType} />
-      <DescriptionSection positionType={positionType} />
-      <OtherPositionSection positionType={positionType} />
-    </main>
+    <>
+      <SEO title={`디프만 - ${position}`} />
+      <main>
+        <HeaderSection positionType={positionType} />
+        <DescriptionSection positionType={positionType} />
+        <OtherPositionSection positionType={positionType} />
+      </main>
+    </>
   );
 }

--- a/src/pages/recruit/index.tsx
+++ b/src/pages/recruit/index.tsx
@@ -1,3 +1,4 @@
+import SEO from '~/components/common/SEO';
 import FaqSection from '~/components/recruit/FaqSection';
 import HeaderSection from '~/components/recruit/HeaderSection';
 import PosiotionSection from '~/components/recruit/PosiotionSection';
@@ -6,12 +7,15 @@ import ScheduleSection from '~/components/recruit/ScheduleSection';
 
 export default function Recruit() {
   return (
-    <main>
-      <HeaderSection />
-      <ScheduleSection />
-      <RequirementSection />
-      <PosiotionSection />
-      <FaqSection />
-    </main>
+    <>
+      <SEO title="디프만 - Recruit" />
+      <main>
+        <HeaderSection />
+        <ScheduleSection />
+        <RequirementSection />
+        <PosiotionSection />
+        <FaqSection />
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## 작업 내용

- `/recruit`, `/recruit/[position]`, `/project`, `/project/[order]` page에 `SEO` 컴포넌트를 적용했어요
- `/interview`의 `HeaderSection`의 이미지가 로딩중일 때 보이던 회색 배경색을 지웠어요 ad1b43a517e17ac0d53c49d8abe431d0a794de00

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
