### PR TITLE
지원하기 배너 적용

### DIFF
--- a/src/components/common/RecruitBanner/RecruitBanner.tsx
+++ b/src/components/common/RecruitBanner/RecruitBanner.tsx
@@ -35,11 +35,13 @@ export default function RecruitBanner() {
   );
 }
 
+export const RECRUIT_BANNER_HEIGHT = 40;
+
 const bannerCss = css`
-  position: fixed;
+  position: sticky;
   top: ${NAV_HEIGHT}px;
   width: 100vw;
-  height: 40px;
+  height: ${RECRUIT_BANNER_HEIGHT}px;
   background-color: ${colors.primary};
   z-index: 8000;
   font-size: 16px;

--- a/src/components/common/RecruitBanner/RecruitBanner.tsx
+++ b/src/components/common/RecruitBanner/RecruitBanner.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { css } from '@emotion/react';
+import { AnimatePresence, motion, Variants } from 'framer-motion';
+
+import { defaultEasing } from '~/constants/motions';
+import useIsInProgress from '~/hooks/use-is-in-progress';
+import { colors } from '~/styles/constants';
+
+import { NAV_HEIGHT } from '../NavigationBar/NavigationBar';
+
+export default function RecruitBanner() {
+  const router = useRouter();
+
+  const isInProgress = useIsInProgress();
+
+  if (!isInProgress) return <></>;
+
+  return (
+    <AnimatePresence exitBeforeEnter>
+      {router.asPath !== '/recruit' && (
+        <Link href="/recruit">
+          <motion.a
+            css={bannerCss}
+            variants={bannerDownVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
+            👉🏻 디프만 12기 지원하러 가기
+          </motion.a>
+        </Link>
+      )}
+    </AnimatePresence>
+  );
+}
+
+const bannerCss = css`
+  position: fixed;
+  top: ${NAV_HEIGHT}px;
+  width: 100vw;
+  height: 40px;
+  background-color: ${colors.primary};
+  z-index: 8000;
+  font-size: 16px;
+  font-weight: 700;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const bannerDownVariants: Variants = {
+  initial: {
+    y: -50,
+    transition: { duration: 0.8, ease: defaultEasing },
+    willChange: 'transform',
+  },
+  animate: {
+    y: 0,
+    transition: { duration: 0.8, ease: defaultEasing, delay: 0.8 },
+    willChange: 'transform',
+  },
+  exit: {
+    y: -50,
+    transition: { duration: 0.8, ease: defaultEasing },
+    willChange: 'transform',
+  },
+};

--- a/src/components/common/RecruitBanner/index.tsx
+++ b/src/components/common/RecruitBanner/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './RecruitBanner';

--- a/src/components/home/ApplySection/ApplySection.tsx
+++ b/src/components/home/ApplySection/ApplySection.tsx
@@ -2,8 +2,6 @@ import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
 import CTAButton from '~/components/common/CTAButton';
-import { NOTION_RECRUIT_PATH } from '~/constants/common';
-import { APPLY_LINK } from '~/constants/common/depromeet';
 import {
   defaultFadeInScaleVariants,
   defaultFadeInVariants,
@@ -32,18 +30,8 @@ export default function ApplySection() {
         디프만 12기 멤버가 되고싶다면
       </motion.h2>
 
-      <motion.a
-        href={APPLY_LINK}
-        target="_blank"
-        rel="noreferrer"
-        variants={defaultFadeInScaleVariants}
-      >
-        <CTAButton
-          disabled={!isInProgress()}
-          onClick={() => {
-            window.open(NOTION_RECRUIT_PATH);
-          }}
-        >
+      <motion.a href={'/recruit'} variants={defaultFadeInScaleVariants}>
+        <CTAButton disabled={!isInProgress()}>
           {isInProgress() ? '지금 지원하기' : '모집 기간이 아닙니다.'}
         </CTAButton>
       </motion.a>

--- a/src/components/home/ApplySection/ApplySection.tsx
+++ b/src/components/home/ApplySection/ApplySection.tsx
@@ -2,32 +2,18 @@ import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
 import CTAButton from '~/components/common/CTAButton';
-import { RECRUIT_STATE } from '~/components/recruit/HeaderSection/HeaderSection';
-import { END_DATE, NOTION_RECRUIT_PATH, START_DATE } from '~/constants/common';
+import { NOTION_RECRUIT_PATH } from '~/constants/common';
 import { APPLY_LINK } from '~/constants/common/depromeet';
 import {
   defaultFadeInScaleVariants,
   defaultFadeInVariants,
   staggerHalf,
 } from '~/constants/motions';
+import useIsInProgress from '~/hooks/use-is-in-progress';
 import { colors, mediaQuery } from '~/styles/constants';
 
 export default function ApplySection() {
-  const startDate = new Date(START_DATE);
-  const endDate = new Date(END_DATE);
-
-  const getCurrentState = () => {
-    const current = new Date();
-
-    if (startDate > current) return RECRUIT_STATE.PREVIOUS;
-    if (endDate < current) return RECRUIT_STATE.FINISH;
-
-    return RECRUIT_STATE.IN_PROGRESS;
-  };
-
-  const isInProgress = () => {
-    return getCurrentState() === RECRUIT_STATE.IN_PROGRESS;
-  };
+  const isInProgress = useIsInProgress();
 
   return (
     <motion.section

--- a/src/components/home/HeaderSection/HeaderSection.tsx
+++ b/src/components/home/HeaderSection/HeaderSection.tsx
@@ -5,6 +5,7 @@ import { motion, useScroll, useTransform, Variants } from 'framer-motion';
 import { ScrollBottomIcon } from '~/components/common/icons';
 import { DepromeetIcon } from '~/components/common/icons/DepromeetIcon';
 import { NAV_HEIGHT } from '~/components/common/NavigationBar/NavigationBar';
+import { RECRUIT_BANNER_HEIGHT } from '~/components/common/RecruitBanner/RecruitBanner';
 import { defaultEasing } from '~/constants/motions';
 import useMediaQuery from '~/hooks/use-media-query';
 import { mediaQuery } from '~/styles/constants';
@@ -102,7 +103,8 @@ const heading1Css = css`
 
 const scrollBottomIconWrapperCss = css`
   position: absolute;
-  bottom: 20px;
+  /* TODO: 배너 내릴 때 변경 */
+  bottom: calc(20px + ${RECRUIT_BANNER_HEIGHT}px);
   left: 50%;
   transform: translateX(-50%);
   margin: 0 auto;

--- a/src/components/interview/InterviewSection/InterviewSection.tsx
+++ b/src/components/interview/InterviewSection/InterviewSection.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 
 import Button from '~/components/common/Button';
 import { NAV_HEIGHT } from '~/components/common/NavigationBar/NavigationBar';
+import { RECRUIT_BANNER_HEIGHT } from '~/components/common/RecruitBanner/RecruitBanner';
 import { defaultFadeInScaleVariants, staggerHalf } from '~/constants/motions';
 import {
   defaultFadeInSlideToRightVariants,
@@ -87,7 +88,8 @@ const buttonWrapperCss = css`
     margin-bottom: 40px;
 
     position: sticky;
-    top: ${NAV_HEIGHT}px;
+    /* TODO: 배너 내릴 때 변경 */
+    top: calc(${NAV_HEIGHT}px + ${RECRUIT_BANNER_HEIGHT}px);
     z-index: 1000;
   }
 `;

--- a/src/constants/common/depromeet.ts
+++ b/src/constants/common/depromeet.ts
@@ -6,5 +6,3 @@ export const DEPROMEET_GITHUB = 'https://github.com/depromeet/';
 export const DEPROMEET_BEHANCE = 'https://www.behance.net/Depromeet';
 
 export const KAKAO_PLUS_FRIEND = 'http://pf.kakao.com/_xoxmcxed';
-
-export const APPLY_LINK = 'https://www.google.com/';

--- a/src/hooks/use-is-in-progress/index.ts
+++ b/src/hooks/use-is-in-progress/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-is-in-progress';

--- a/src/hooks/use-is-in-progress/use-is-in-progress.ts
+++ b/src/hooks/use-is-in-progress/use-is-in-progress.ts
@@ -1,0 +1,22 @@
+import { RECRUIT_STATE } from '~/components/recruit/HeaderSection/HeaderSection';
+import { END_DATE, START_DATE } from '~/constants/common';
+
+export default function useIsInProgress() {
+  const startDate = new Date(START_DATE);
+  const endDate = new Date(END_DATE);
+
+  const getCurrentState = () => {
+    const current = new Date();
+
+    if (startDate > current) return RECRUIT_STATE.PREVIOUS;
+    if (endDate < current) return RECRUIT_STATE.FINISH;
+
+    return RECRUIT_STATE.IN_PROGRESS;
+  };
+
+  const isInProgress = () => {
+    return getCurrentState() === RECRUIT_STATE.IN_PROGRESS;
+  };
+
+  return isInProgress;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/react';
 import Footer from '~/components/common/Footer';
 import NavigationBar from '~/components/common/NavigationBar';
 import { NAV_HEIGHT } from '~/components/common/NavigationBar/NavigationBar';
+import RecruitBanner from '~/components/common/RecruitBanner';
 import { BASE_URL } from '~/constants/common';
 import useRecordPageview from '~/hooks/use-record-pageview';
 import { layoutCss } from '~/styles/css';
@@ -27,6 +28,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <GlobalStyle />
 
       <NavigationBar />
+      <RecruitBanner />
       <div css={contentLayoutCss(router.route)}>
         <Component {...pageProps} />
       </div>


### PR DESCRIPTION
## 작업 내용

- 상단 `지원하러 가기` 배너를 개발, 적용했어요
  - `absoulte`, `sticky` 포지션이라 배너와 함께 변경이 필요한 두 곳에 코멘트와 함께 적용했어요 08dcbd4db59f2904b5f2097458870fa840fa6420

  - `/recruit`에서는 배너가 안보이는게 자연스러운 것 같아서, 그렇게 적용했어요
 
- `useIsInProgress` 훅을 개발했어요
  - 현재 모집중인지를 `boolean`으로 반환해요
  
  - `home/ApplySection`, `RecruitBanner`에 적용했어요 

- `/`의 지원하기 버튼이 `/recruit`으로 이동하도록 수정했어요

## 스크린샷

![스크린샷 2022-08-22 오후 7 03 23](https://user-images.githubusercontent.com/26461307/185895570-f7920b73-c6c3-4b24-8e00-bdcf3e867937.png)

![스크린샷 2022-08-22 오후 7 03 56](https://user-images.githubusercontent.com/26461307/185895668-25d53002-4f4d-42f6-9e6b-b923e6847b1e.png)

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
