### PR TITLE
Link passHref, Button aria-label 적용

### DIFF
--- a/src/components/common/NavigationBar/Anchor.tsx
+++ b/src/components/common/NavigationBar/Anchor.tsx
@@ -13,7 +13,7 @@ export default function Anchor({ href, name }: Props) {
   const router = useRouter();
 
   return (
-    <Link href={href}>
+    <Link href={href} passHref>
       <a css={anchorCss(router.asPath, router.asPath.includes(href))}>{name}</a>
     </Link>
   );

--- a/src/components/common/NavigationBar/HamburgerButton.tsx
+++ b/src/components/common/NavigationBar/HamburgerButton.tsx
@@ -6,7 +6,7 @@ import Svg from '../icons/Svg';
 
 export default function HamburgerButton({ toggleIsOpen }: { toggleIsOpen: VoidFunction }) {
   return (
-    <button onClick={toggleIsOpen}>
+    <button onClick={toggleIsOpen} aria-label="hamburger button">
       <Svg>
         <Path
           variants={{

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -27,7 +27,7 @@ export default function NavigationBar() {
       <>
         <motion.nav css={navCss} animate={isOpen ? 'open' : 'closed'} variants={mobileNavVariants}>
           <div css={wrapperCss}>
-            <Link href="/">
+            <Link href="/" passHref>
               <a css={anchorCss}>
                 <DepromeetIcon />
               </a>
@@ -49,7 +49,7 @@ export default function NavigationBar() {
   return (
     <nav css={navCss}>
       <div css={wrapperCss}>
-        <Link href="/">
+        <Link href="/" passHref>
           <a css={anchorCss}>
             <DepromeetIcon />
           </a>

--- a/src/components/common/RecruitBanner/RecruitBanner.tsx
+++ b/src/components/common/RecruitBanner/RecruitBanner.tsx
@@ -19,7 +19,7 @@ export default function RecruitBanner() {
   return (
     <AnimatePresence exitBeforeEnter>
       {router.asPath !== '/recruit' && (
-        <Link href="/recruit">
+        <Link href="/recruit" passHref>
           <motion.a
             css={bannerCss}
             variants={bannerDownVariants}

--- a/src/components/home/ApplySection/ApplySection.tsx
+++ b/src/components/home/ApplySection/ApplySection.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
@@ -30,11 +31,13 @@ export default function ApplySection() {
         디프만 12기 멤버가 되고싶다면
       </motion.h2>
 
-      <motion.a href={'/recruit'} variants={defaultFadeInScaleVariants}>
-        <CTAButton disabled={!isInProgress()}>
-          {isInProgress() ? '지금 지원하기' : '모집 기간이 아닙니다.'}
-        </CTAButton>
-      </motion.a>
+      <Link href="/recruit" passHref>
+        <motion.a variants={defaultFadeInScaleVariants}>
+          <CTAButton disabled={!isInProgress()}>
+            {isInProgress() ? '지금 지원하기' : '모집 기간이 아닙니다.'}
+          </CTAButton>
+        </motion.a>
+      </Link>
     </motion.section>
   );
 }

--- a/src/components/home/MoreInfoSection/MoreInfoSection.tsx
+++ b/src/components/home/MoreInfoSection/MoreInfoSection.tsx
@@ -132,7 +132,7 @@ function LinkArticle({ href, heading, image, description, blank = false }: LinkA
   }
 
   return (
-    <Link href={href}>
+    <Link href={href} passHref>
       <motion.a
         css={anchorCss}
         variants={defaultFadeInUpVariants}


### PR DESCRIPTION
## 작업 내용

![스크린샷 2022-08-23 오전 8 18 09](https://user-images.githubusercontent.com/26461307/186036090-5cf1c999-72ee-48af-bbea-4eda807f569e.png)

- next `Link` 태그만 사용된 곳, 하위 a 태그에 href가 전달이 되지 않았던 경우들에 대해 `passHref` 옵션으로 전달하였습니다

> root route에만 적용했어요

- 접근성을 이유로 햄버거 버튼에 `aria-label`을 적용했어요


## 스크린샷

적용 이후


![스크린샷 2022-08-23 오전 8 19 52](https://user-images.githubusercontent.com/26461307/186036264-947148fa-80c3-49f2-94d2-d6bcb87c2cc0.png)

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
