### PR TITLE
recruit/[position] route SSG 적용

### DIFF
--- a/src/pages/recruit/[position]/index.tsx
+++ b/src/pages/recruit/[position]/index.tsx
@@ -1,28 +1,52 @@
-import Error from 'next/error';
-import { useRouter } from 'next/router';
-import { ParsedUrlQuery } from 'querystring';
-
 import SEO from '~/components/common/SEO';
 import { POSITION_TYPE, PositionType } from '~/components/recruit-detail/constants';
 import DescriptionSection from '~/components/recruit-detail/DescriptionSection';
 import HeaderSection from '~/components/recruit-detail/HeaderSection';
 import OtherPositionSection from '~/components/recruit-detail/OtherPositionSection';
 
-export default function RecruitDetail() {
-  const router = useRouter();
-  const { position } = router.query as ParsedUrlQuery & { position: string };
-  const positionType = POSITION_TYPE[position?.toUpperCase() as PositionType];
+interface Props {
+  position: typeof POSITION_TYPE[PositionType];
+}
 
-  if (!position && !positionType) return <Error statusCode={404} />;
-
+export default function RecruitDetail({ position }: Props) {
   return (
     <>
       <SEO title={`디프만 - ${position}`} />
       <main>
-        <HeaderSection positionType={positionType} />
-        <DescriptionSection positionType={positionType} />
-        <OtherPositionSection positionType={positionType} />
+        <HeaderSection positionType={position} />
+        <DescriptionSection positionType={position} />
+        <OtherPositionSection positionType={position} />
       </main>
     </>
   );
+}
+
+interface Paths {
+  params: {
+    // NOTE: 대소문자 구분을 위해 string으로 정의
+    position: string;
+  };
+}
+
+export async function getStaticPaths() {
+  const paths: Paths[] = [];
+
+  Object.values(POSITION_TYPE).forEach(position => {
+    paths.push({ params: { position: position.toLowerCase() } });
+  });
+
+  return { paths, fallback: 'blocking' };
+}
+
+export async function getStaticProps({ params }: Paths) {
+  const { position } = params;
+  const upperCasePosition = position.toUpperCase();
+
+  if (!POSITION_TYPE.hasOwnProperty(upperCasePosition)) {
+    return { notFound: true };
+  }
+
+  return {
+    props: { position: upperCasePosition },
+  };
 }


### PR DESCRIPTION
## 작업 내용

클라이언트 사이드에서 유효한 포지션인지 판별되고 있는 것을 빌드 타임에 위임하도록
`getStaticPaths`, `getStaticProps`를 이용해 정적 페이지로 생성하도록 했어요

## 스크린샷

![스크린샷 2022-08-23 오후 1 51 19](https://user-images.githubusercontent.com/26461307/186072801-284ae0d2-a620-4f79-98f4-202398bf259e.png)


## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
