### PR TITLE
모바일 환경 layout shifting 개선

### DIFF
--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion, Variants } from 'framer-motion';
 import { defaultEasing } from '~/constants/motions';
 import useMediaQuery from '~/hooks/use-media-query';
 import { colors } from '~/styles/constants';
-import { layoutCss } from '~/styles/css';
+import hideWhenMobile, { layoutCss } from '~/styles/css';
 
 import Anchor from './Anchor';
 import DimOverlay from './DimOverlay';
@@ -47,7 +47,7 @@ export default function NavigationBar() {
   }
 
   return (
-    <nav css={navCss}>
+    <nav css={[navCss, hideWhenMobile]}>
       <div css={wrapperCss}>
         <Link href="/" passHref>
           <a css={anchorCss}>

--- a/src/hooks/use-media-query/use-media-query.ts
+++ b/src/hooks/use-media-query/use-media-query.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { size, SizeKey } from '~/styles/constants';
 
@@ -7,24 +7,28 @@ export function useMediaQuery(width: number): boolean;
 export function useMediaQuery(sizeKey: SizeKey): boolean;
 
 export default function useMediaQuery(width: number | SizeKey) {
-  const [targetReached, setTargetReached] = useState(false);
+  const [targetReached, setTargetReached] = useState<boolean>(false);
+
+  const updateTarget = useCallback((e: MediaQueryListEvent) => {
+    if (e.matches) {
+      setTargetReached(true);
+    } else {
+      setTargetReached(false);
+    }
+  }, []);
 
   useEffect(() => {
-    function updateTarget(e: MediaQueryListEvent) {
-      setTargetReached(e.matches);
-    }
-
     const targetWidth = typeof width === 'number' ? `${width}px` : size[width];
 
     const media = window.matchMedia(`(max-width: ${targetWidth})`);
-    media.addListener(updateTarget);
+    media.addEventListener('change', updateTarget);
 
     if (media.matches) {
       setTargetReached(true);
     }
 
-    return () => media.removeListener(updateTarget);
-  }, [width]);
+    return () => media.removeEventListener('change', updateTarget);
+  }, [updateTarget, width]);
 
   return targetReached;
 }

--- a/src/styles/css/hideWhenMobile.ts
+++ b/src/styles/css/hideWhenMobile.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+import { mediaQuery } from '../constants';
+
+const hideWhenMobile = css`
+  ${mediaQuery('xs')} {
+    display: none;
+    appearance: none;
+  }
+`;
+
+export default hideWhenMobile;

--- a/src/styles/css/index.ts
+++ b/src/styles/css/index.ts
@@ -1,1 +1,2 @@
+export { default } from './hideWhenMobile';
 export * from './layoutCss';


### PR DESCRIPTION
closes #177 

## 작업 내용

문제가 되는 지점은 `use-media-query`가 반환하는 값이 렌더링 이후에 갱신되어

**모바일 환경일 경우 데스크톱 기준으로 렌더링 하고, 이후에 변경되는 것이에요**


- `hideWhenMobile` css를 적용해서 DOM 요소의 경우 먼저 렌더링되는 경우를 방지했어요

  ```tsx
  {isMobile ? <div>mobile</div> : <div css={hideWhenMobile}>desktop</div>}
  ```

  - 근데 아래와 같은 경우는 어떻게 대응해야 할지 모르겠어요 ㅠ 

    ```tsx
    <Image src={isMobile ? MOBILE_IMAGE : DESKTOP_IMAGE } />
    ```


- `use-media-query`에서 `false`가 되는 경우를 대응했어요

## 고민

현재 많은 곳에서 사용되고 있어서, 전부 대응하는 것보단 `use-media-query` 로직을 개선하는 방향이 우선시 될 거 같아 고민이에요!
