### PR TITLE
모바일 환경 layout shifting 개선 v2

### DIFF
--- a/src/hooks/use-media-query/use-media-query.ts
+++ b/src/hooks/use-media-query/use-media-query.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { size, SizeKey } from '~/styles/constants';
+import { SIZE, size, SizeKey } from '~/styles/constants';
 
 import { useUserAgent } from '../use-user-agent';
 
@@ -11,7 +11,8 @@ export function useMediaQuery(sizeKey: SizeKey): boolean;
 export default function useMediaQuery(width: number | SizeKey) {
   const { isMobileAgent } = useUserAgent();
   const targetWidth = typeof width === 'number' ? `${width}px` : size[width];
-  const isMobileSize = targetWidth <= size.xs && isMobileAgent;
+  const isMobileSize = (width <= SIZE.xs || targetWidth === size.xs) && isMobileAgent;
+
   const [targetReached, setTargetReached] = useState<boolean>(isMobileSize);
 
   const updateTarget = useCallback((e: MediaQueryListEvent) => {

--- a/src/hooks/use-media-query/use-media-query.ts
+++ b/src/hooks/use-media-query/use-media-query.ts
@@ -2,12 +2,17 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { size, SizeKey } from '~/styles/constants';
 
+import { useUserAgent } from '../use-user-agent';
+
 export function useMediaQuery(width: number): boolean;
 
 export function useMediaQuery(sizeKey: SizeKey): boolean;
 
 export default function useMediaQuery(width: number | SizeKey) {
-  const [targetReached, setTargetReached] = useState<boolean>(false);
+  const { isMobileAgent } = useUserAgent();
+  const targetWidth = typeof width === 'number' ? `${width}px` : size[width];
+  const isMobileSize = targetWidth <= size.xs && isMobileAgent;
+  const [targetReached, setTargetReached] = useState<boolean>(isMobileSize);
 
   const updateTarget = useCallback((e: MediaQueryListEvent) => {
     if (e.matches) {
@@ -18,8 +23,6 @@ export default function useMediaQuery(width: number | SizeKey) {
   }, []);
 
   useEffect(() => {
-    const targetWidth = typeof width === 'number' ? `${width}px` : size[width];
-
     const media = window.matchMedia(`(max-width: ${targetWidth})`);
     media.addEventListener('change', updateTarget);
 
@@ -28,7 +31,7 @@ export default function useMediaQuery(width: number | SizeKey) {
     }
 
     return () => media.removeEventListener('change', updateTarget);
-  }, [updateTarget, width]);
+  }, [updateTarget, targetWidth]);
 
   return targetReached;
 }

--- a/src/hooks/use-media-query/use-media-query.ts
+++ b/src/hooks/use-media-query/use-media-query.ts
@@ -28,6 +28,8 @@ export default function useMediaQuery(width: number | SizeKey) {
 
     if (media.matches) {
       setTargetReached(true);
+    } else {
+      setTargetReached(false);
     }
 
     return () => media.removeEventListener('change', updateTarget);

--- a/src/hooks/use-user-agent/index.ts
+++ b/src/hooks/use-user-agent/index.ts
@@ -1,0 +1,2 @@
+export { useUserAgent } from './use-user-agent';
+export { UserAgentContext } from './user-agent-context';

--- a/src/hooks/use-user-agent/use-user-agent.ts
+++ b/src/hooks/use-user-agent/use-user-agent.ts
@@ -4,7 +4,7 @@ import { UserAgentContext } from './user-agent-context';
 
 export const useUserAgent = () => {
   const userAgent = useContext(UserAgentContext);
-  const isMobileAgent = /iPhone|iPad|iPod|Android/i.test(userAgent);
+  const isMobileAgent = /iPhone|iPod|Android/i.test(userAgent);
 
   if (userAgent === undefined) {
     throw new Error('useUserAgent should be used within CounterProvider');

--- a/src/hooks/use-user-agent/use-user-agent.ts
+++ b/src/hooks/use-user-agent/use-user-agent.ts
@@ -7,7 +7,7 @@ export const useUserAgent = () => {
   const isMobileAgent = /iPhone|iPod|Android/i.test(userAgent);
 
   if (userAgent === undefined) {
-    throw new Error('useUserAgent should be used within CounterProvider');
+    throw new Error('useUserAgent should be used within UserAgentContext.Provider');
   }
 
   return { userAgent, isMobileAgent };

--- a/src/hooks/use-user-agent/use-user-agent.ts
+++ b/src/hooks/use-user-agent/use-user-agent.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+
+import { UserAgentContext } from './user-agent-context';
+
+export const useUserAgent = () => {
+  const userAgent = useContext(UserAgentContext);
+  const isMobileAgent = /iPhone|iPad|iPod|Android/i.test(userAgent);
+
+  if (userAgent === undefined) {
+    throw new Error('useUserAgent should be used within CounterProvider');
+  }
+
+  return { userAgent, isMobileAgent };
+};

--- a/src/hooks/use-user-agent/user-agent-context.ts
+++ b/src/hooks/use-user-agent/user-agent-context.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const UserAgentContext = createContext<string>('');

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,7 +12,11 @@ import { UserAgentContext } from '~/hooks/use-user-agent';
 import { layoutCss } from '~/styles/css';
 import GlobalStyle from '~/styles/GlobalStyle';
 
-export default function App({ Component, pageProps, userAgent }: AppProps & { userAgent: string }) {
+interface InitialProps {
+  userAgent: string;
+}
+
+export default function App({ Component, pageProps, userAgent }: AppProps & InitialProps) {
   const router = useRouter();
   const currentUrl = BASE_URL + router.route;
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import type { AppProps } from 'next/app';
+import type { AppContext, AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
@@ -8,17 +8,18 @@ import NavigationBar from '~/components/common/NavigationBar';
 import { NAV_HEIGHT } from '~/components/common/NavigationBar/NavigationBar';
 import { BASE_URL } from '~/constants/common';
 import useRecordPageview from '~/hooks/use-record-pageview';
+import { UserAgentContext } from '~/hooks/use-user-agent';
 import { layoutCss } from '~/styles/css';
 import GlobalStyle from '~/styles/GlobalStyle';
 
-export default function App({ Component, pageProps }: AppProps) {
+export default function App({ Component, pageProps, userAgent }: AppProps & { userAgent: string }) {
   const router = useRouter();
   const currentUrl = BASE_URL + router.route;
 
   useRecordPageview();
 
   return (
-    <>
+    <UserAgentContext.Provider value={userAgent}>
       <Head>
         <link rel="canonical" href={currentUrl} />
         <meta property="og:url" content={currentUrl} />
@@ -32,7 +33,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <Component {...pageProps} />
       </div>
       <Footer />
-    </>
+    </UserAgentContext.Provider>
   );
 }
 
@@ -40,3 +41,9 @@ const contentLayoutCss = (routerRoute: string) => css`
   ${layoutCss(routerRoute)}
   margin-top: ${NAV_HEIGHT}px;
 `;
+
+App.getInitialProps = async ({ ctx }: AppContext) => {
+  const userAgent = ctx.req?.headers['user-agent'] || 'Desktop';
+
+  return { userAgent };
+};

--- a/src/styles/constants/media.ts
+++ b/src/styles/constants/media.ts
@@ -1,9 +1,17 @@
+export const SIZE = {
+  xs: 650,
+  sm: 960,
+  md: 1280,
+  lg: 1400,
+  xl: 1920,
+} as const;
+
 export const size = {
-  xs: '650px',
-  sm: '960px',
-  md: '1280px',
-  lg: '1400px',
-  xl: '1920px',
+  xs: `${SIZE.xs}px`,
+  sm: `${SIZE.sm}px`,
+  md: `${SIZE.md}px`,
+  lg: `${SIZE.lg}px`,
+  xl: `${SIZE.xl}px`,
 } as const;
 
 export type SizeKey = keyof typeof size;


### PR DESCRIPTION
## 작업 내용
next의  getInitialProps 기능을 활용하여, req의 userAgent를 확인하여, userAgent를 모든 페이지에서 받습니다.
이후, contextapi에 담아서 useMediaQuery에서 mobile인 경우에 대응을 할 수 있도록하는 코드를 추가적으로 작성했습니다.

### 질문...
사용자가 보기에 굳이 잘작동되는코드에 해당사항을 반영을 진행할까에 대한 고민....좀 더 코드가 지저분해진것 같긴합니다.
지저분한 이유는!!! `useMediaQuery`가 `useUserAgent` hooks에 종속적이게 변하였습니다. 아주 좋지않아....
대응방법은 이둘을 사용하는 hooks를 하나 만드는것이 좋을것같다고 생각하기 떄문!

또한 지금 코드가 적용된다고 #178를  지울 수 있는것도 아닙니다. 왜냐하면, android 테블릿이 있기 때문이죠..
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷
https://user-images.githubusercontent.com/59507527/205951030-e79b98e3-f4c5-498b-9a66-e53272b15185.mov


### 모바일 / 데스크탑 환경에서 response로 온 dom을 확인하였을 경우, dom이 날라오는 형태를 보았을 경우, 유의미한 차이가 있다고 볼 순 있겠습니다.
**AS-IS**
<img width="863" alt="image" src="https://user-images.githubusercontent.com/59507527/205953452-8ebcc6ed-1c6e-4a2f-b5c6-c2878a166a39.png">


**TO-BE**
<img width="1921" alt="image" src="https://user-images.githubusercontent.com/59507527/205951791-d0b299c9-e79e-4078-b49b-14836d3f4b43.png">
or
<img width="1921" alt="image" src="https://user-images.githubusercontent.com/59507527/205951716-4cfea91b-c5fb-4d9b-8e22-2c0780bd8b0d.png">
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

