### PR TITLE
공통 유틸 및 Apply Section 개발

### DIFF
--- a/src/components/common/ApplySection/ApplySection.tsx
+++ b/src/components/common/ApplySection/ApplySection.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+import { css, Interpolation, Theme } from '@emotion/react';
+
+import { NOTION_RECRUIT_PATH } from '~/constants/common';
+import { colors, mediaQuery } from '~/styles/constants';
+import { section36HeadingCss, sectionSmallCss } from '~/styles/css';
+
+interface Props {
+  wrapperCss?: Interpolation<Theme>;
+}
+
+export default function ApplySection({ wrapperCss }: Props) {
+  return (
+    <section css={[sectionCss, wrapperCss]}>
+      <small css={smallCss}>APPLY</small>
+      <h2 css={headingCss}>
+        이제 여러분 차례예요!
+        <br />
+        디프만 13기 멤버가 되고 싶다면
+      </h2>
+      <Link css={linkCss} href={NOTION_RECRUIT_PATH} target="_blank" rel="noopener noreferrer">
+        바로 지원하기
+      </Link>
+    </section>
+  );
+}
+
+const sectionCss = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+`;
+
+const smallCss = css`
+  ${sectionSmallCss};
+  margin-bottom: 10px;
+`;
+
+const headingCss = css`
+  ${section36HeadingCss};
+  margin-bottom: 60px;
+
+  ${mediaQuery('xs')} {
+    margin-bottom: 36px;
+  }
+`;
+
+const linkCss = css`
+  border-radius: 2px;
+  padding: 16px 98px;
+  background-color: ${colors.black};
+
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 24px;
+  color: ${colors.gray100};
+
+  ${mediaQuery('xs')} {
+    padding: 18px 60px;
+    font-size: 16px;
+    line-height: 19px;
+  }
+`;

--- a/src/components/common/ApplySection/index.tsx
+++ b/src/components/common/ApplySection/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ApplySection';

--- a/src/constants/common/common.ts
+++ b/src/constants/common/common.ts
@@ -5,6 +5,7 @@ export const HOTJAR_ID = '3115834';
 
 export const BASE_URL = 'https://www.depromeet.com';
 
+// TODO: 링크 최신화 해야 함
 export const NOTION_RECRUIT_PATH =
   'https://www.notion.so/depromeet/12-8e4fc4ef30fd4853a522258d117d3c33';
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,13 @@
+import ApplySection from '~/components/common/ApplySection';
 import SEO from '~/components/common/SEO';
 
 export default function Root() {
   return (
     <>
       <SEO />
-      <main></main>
+      <main>
+        <ApplySection />
+      </main>
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,24 @@
+import { css } from '@emotion/react';
+
 import ApplySection from '~/components/common/ApplySection';
 import SEO from '~/components/common/SEO';
+import { mediaQuery } from '~/styles/constants';
 
 export default function Root() {
   return (
     <>
       <SEO />
       <main>
-        <ApplySection />
+        <ApplySection wrapperCss={applySectionMarginCss} />
       </main>
     </>
   );
 }
+
+const applySectionMarginCss = css`
+  margin-bottom: 240px;
+
+  ${mediaQuery('xs')} {
+    margin-bottom: 150px;
+  }
+`;

--- a/src/styles/constants/colors.ts
+++ b/src/styles/constants/colors.ts
@@ -5,4 +5,5 @@ export const colors = {
   gray900: '#41434D',
   gray600: '#A0A1A6',
   gray500: '#B8B9BC',
+  gray100: '#F7F7F7',
 } as const;

--- a/src/styles/css/index.ts
+++ b/src/styles/css/index.ts
@@ -1,1 +1,2 @@
 export * from './layoutCss';
+export * from './typo';

--- a/src/styles/css/typo.ts
+++ b/src/styles/css/typo.ts
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+
+import { colors } from '../constants';
+
+export const sectionSmallCss = css`
+  font-weight: 600;
+  font-size: 0.875rem;
+  line-height: 140%;
+  color: ${colors.gray500};
+`;
+
+export const section36HeadingCss = css`
+  font-weight: 600;
+  font-size: 2.25rem;
+  line-height: 43px;
+  color: ${colors.black};
+`;
+
+export const section40HeadingCss = css`
+  font-weight: 600;
+  font-size: 2.5rem;
+  line-height: 48px;
+  color: ${colors.black};
+`;

--- a/src/styles/css/typo.ts
+++ b/src/styles/css/typo.ts
@@ -1,12 +1,17 @@
 import { css } from '@emotion/react';
 
-import { colors } from '../constants';
+import { colors, mediaQuery } from '../constants';
 
 export const sectionSmallCss = css`
   font-weight: 600;
   font-size: 0.875rem;
   line-height: 140%;
   color: ${colors.gray500};
+
+  ${mediaQuery('xs')} {
+    font-size: 12px;
+    line-height: 14px;
+  }
 `;
 
 export const section36HeadingCss = css`
@@ -14,6 +19,11 @@ export const section36HeadingCss = css`
   font-size: 2.25rem;
   line-height: 43px;
   color: ${colors.black};
+
+  ${mediaQuery('xs')} {
+    font-size: 22px;
+    line-height: 140%;
+  }
 `;
 
 export const section40HeadingCss = css`
@@ -21,4 +31,9 @@ export const section40HeadingCss = css`
   font-size: 2.5rem;
   line-height: 48px;
   color: ${colors.black};
+
+  ${mediaQuery('xs')} {
+    font-size: 22px;
+    line-height: 140%;
+  }
 `;


### PR DESCRIPTION
## 작업 내용

- ### Apply Section을 개발했어요
  - 반응형 디자인도 나와서 적용했어요

<img width="682" alt="스크린샷 2023-03-02 오후 2 18 56" src="https://user-images.githubusercontent.com/26461307/222337864-bb8d1f8b-c430-43e2-a123-0676a0190cb7.png">
 
  - 레이아웃이 페이지 마다 다르기 때문에 `wrapperCss`를 받을 수 있도록 해두었어요
  다음과 같이 쓸 수 있어요
https://github.com/depromeet/www.depromeet.com/blob/c485cea45aaac00ab4d15b347b709b60f7ab611d/src/pages/index.tsx#L7-L24

- ### 재사용되는 typo 3개에 한해서 모듈화 해두었어요
 
https://github.com/depromeet/www.depromeet.com/blob/c485cea45aaac00ab4d15b347b709b60f7ab611d/src/styles/css/typo.ts#L5-L39

  - 각각 section의 small 태그와 title에 사용하면 돼용
  - title이 36 픽셀인 것과 40 픽셀인 것으로 나뉘어 있어서 분리했어요


## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
