### PR TITLE
Footer 모바일 사이즈 대응

### DIFF
--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -9,7 +9,7 @@ import {
   DEPROMEET_INSTAGRAM,
   DEPROMEET_MEDIUM,
 } from '~/constants/common';
-import { colors } from '~/styles/constants';
+import { colors, mediaQuery } from '~/styles/constants';
 import { layoutCss } from '~/styles/css';
 
 export default function Footer() {
@@ -39,11 +39,28 @@ const footerCss = css`
   justify-content: center;
   align-items: center;
   gap: 32px;
+
+  ${mediaQuery('xs')} {
+    padding-top: 6px;
+    gap: 24px;
+    justify-content: start;
+  }
 `;
 
 const anchorSectionCss = css`
   display: flex;
   gap: 3.25rem;
+
+  ${mediaQuery('xs')} {
+    max-width: 348px;
+
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+
+    row-gap: 14px;
+    column-gap: 32px;
+  }
 `;
 
 const copyRightCss = css`


### PR DESCRIPTION
## 작업 내용

- Footer의 모바일 사이즈를 대응했어오
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷

<img width="548" alt="스크린샷 2023-03-02 오후 3 30 41" src="https://user-images.githubusercontent.com/26461307/222349004-167cec77-7a5a-4e7b-95d2-8935ccb65e04.png">

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
