### PR TITLE
feat: 커스텀 커서 window 밖으로 나갈 경우, 안보이게 하기

### DIFF
--- a/src/components/common/CustomCursor/CustomCursor.tsx
+++ b/src/components/common/CustomCursor/CustomCursor.tsx
@@ -13,13 +13,21 @@ export default function CustomCursor() {
     if (cursorRef == null || cursorRef.current == null) return;
 
     function handleMouseMove(e: MouseEvent) {
-      cursorRef.current?.setAttribute('style', `top: ${e.pageY}px;` + `left: ${e.pageX}px;`);
+      cursorRef.current?.setAttribute(
+        'style',
+        `top: ${e.pageY}px;` + `left: ${e.pageX}px; display: inline`
+      );
     }
-
     document.addEventListener('mousemove', handleMouseMove);
+
+    function handleMouseOut() {
+      cursorRef.current?.setAttribute('style', `display: none`);
+    }
+    window.addEventListener('mouseout', handleMouseOut);
 
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseout', handleMouseOut);
     };
   }, []);
 


### PR DESCRIPTION
## 작업 내용
아래의 코드를 이용해 윈도우 밖으로 나가는 이벤트 일경우, display: none 처리를  하는 코드를 추가했습니다.

```ts
function handleMouseOut(e: MouseEvent) {
    cursorRef.current?.setAttribute('style', `display: none`);
  }
window.addEventListener('mouseout', handleMouseOut);
```

필요없다면 과감히 패스~!
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷
AS-IS
<img width="548" alt="image" src="https://user-images.githubusercontent.com/59507527/222765954-bafde642-32f0-420f-8dd6-555c84c3c14c.png">

TO-BE
<img width="548" alt="image" src="https://user-images.githubusercontent.com/59507527/222766432-7b0b0c4a-3000-4faa-88c5-192aea47b486.png">
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법
x
<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스
x
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

closed #202 