### PR TITLE
모바일 커스텀커서 비활성화 및 아이패드 사파리 userAgent 대응

### DIFF
--- a/src/components/common/CustomCursor/CustomCursor.tsx
+++ b/src/components/common/CustomCursor/CustomCursor.tsx
@@ -1,11 +1,19 @@
 import { useEffect, useRef } from 'react';
 import { css } from '@emotion/react';
 
+import { useUserAgent } from '~/hooks/use-user-agent';
 import useCursorState from '~/store/cursor/useCursorState';
 
 const CURSOR_URL = '/common/cursor.webp';
 
-export default function CustomCursor() {
+export default function CustomCursorWrapper() {
+  const { isMobileAgent } = useUserAgent();
+
+  if (isMobileAgent) return <></>;
+  return <CustomCursor />;
+}
+
+function CustomCursor() {
   const cursorRef = useRef<HTMLSpanElement>(null);
   const { cursorState } = useCursorState();
 

--- a/src/components/common/CustomCursor/CustomCursor.tsx
+++ b/src/components/common/CustomCursor/CustomCursor.tsx
@@ -20,14 +20,17 @@ export default function CustomCursor() {
     }
     document.addEventListener('mousemove', handleMouseMove);
 
-    function handleMouseOut() {
+    function handleMouseLeave() {
       cursorRef.current?.setAttribute('style', `display: none`);
     }
-    window.addEventListener('mouseout', handleMouseOut);
+    document.addEventListener('mouseleave', handleMouseLeave);
+    // NOTE: firefox 대응
+    document.documentElement.addEventListener('mouseleave', handleMouseLeave);
 
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseout', handleMouseOut);
+      document.removeEventListener('mouseleave', handleMouseLeave);
+      document.documentElement.removeEventListener('mouseleave', handleMouseLeave);
     };
   }, []);
 

--- a/src/hooks/use-user-agent/use-user-agent.ts
+++ b/src/hooks/use-user-agent/use-user-agent.ts
@@ -1,10 +1,17 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 
 import { UserAgentContext } from './user-agent-context';
+import useEffectOnce from '../use-effect-once';
 
 export const useUserAgent = () => {
   const userAgent = useContext(UserAgentContext);
-  const isMobileAgent = /iPhone|iPod|Android/i.test(userAgent);
+  const [isMobileAgent, setIsMobileAgent] = useState(/iPhone|iPod|iPad|Android/i.test(userAgent));
+
+  useEffectOnce(() => {
+    if (navigator.maxTouchPoints > 1) {
+      setIsMobileAgent(true);
+    }
+  });
 
   if (userAgent === undefined) {
     throw new Error('useUserAgent should be used within UserAgentContext.Provider');


### PR DESCRIPTION
## 작업 내용

- `mouseout` 이벤트가 마우스가 나가지 않아도 호출되길래 `mouseleave` 이벤트로 바꾸어 주었어요
  - 파이어폭스 환경에서 mouseleave 이벤트가 동작하지 않아 `documentElement`에 부착하는 방법으로 대응했어요

- useUserAgent를 이용해서 mobile일 시 `CustomCursor`를 그리지 않도록 했어요

- 아이패드에서도 비활성화하는게 자연스러울거라 생각했어요

  - 근데 사파리 개발자 도구로 userAgent 찍어보는데 맥이랑 똑같이 나오더라구요
  - 아래 레퍼런스 참고해서 터치 포인트를 이용해 대응했어요

> 아이폰 크롬, 카카오 인앱, 파이어폭스, 사파리, 엣지, 오페라 확인 완

> 아이패드 크롬, 사파리, 카카오 인앱 확인 완

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

- https://minemanemo.tistory.com/101
