### PR TITLE
fix: 모집 페이지 빠진 clickable 및 frontend web으로 텍스트 변경

### DIFF
--- a/src/components/recruit-detail/PreviousSection.tsx
+++ b/src/components/recruit-detail/PreviousSection.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 
 import { colors, mediaQuery } from '~/styles/constants';
 
+import { ClickableButton } from '../common/Clickable';
 import { ArrowIcon } from '../common/icons';
 
 export default function PreviousSection() {
@@ -10,14 +11,14 @@ export default function PreviousSection() {
 
   return (
     <div css={sectionCss}>
-      <button
+      <ClickableButton
         onClick={() => {
           router.back();
         }}
       >
         <ArrowIcon width={18} height={18} color="black" />
         이전
-      </button>
+      </ClickableButton>
     </div>
   );
 }

--- a/src/components/recruit-detail/TipSection.tsx
+++ b/src/components/recruit-detail/TipSection.tsx
@@ -7,6 +7,7 @@ import { section40HeadingCss, sectionSmallCss } from '~/styles/css';
 
 import { POSITION_TIPS, POSITION_TYPE, PositionType, TIP_BASE_IMAGE_URL } from './constants';
 import { sectionCss, sectionHeadingCss } from './RecruitDetail.style';
+import { ClickableButton } from '../common/Clickable';
 import { ArrowIcon } from '../common/icons';
 
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
@@ -63,9 +64,9 @@ const RenderArrowPrev = (clickHandler: () => void, isNeedController: boolean) =>
   return (
     <>
       {isNeedController && (
-        <div css={[baseArrowCss, prevCss]} onClick={clickHandler}>
+        <ClickableButton css={[baseArrowCss, prevCss]} onClick={clickHandler}>
           <ArrowIcon width={32} height={32} color="black" />
-        </div>
+        </ClickableButton>
       )}
     </>
   );
@@ -74,9 +75,9 @@ const RenderArrowNext = (clickHandler: () => void, isNeedController: boolean) =>
   return (
     <>
       {isNeedController && (
-        <div css={[baseArrowCss, nextCss]} onClick={clickHandler}>
+        <ClickableButton css={[baseArrowCss, nextCss]} onClick={clickHandler}>
           <ArrowIcon width={32} height={32} color="black" />
-        </div>
+        </ClickableButton>
       )}
     </>
   );
@@ -86,9 +87,9 @@ const RenderIndicator = (
   isSelected: boolean
 ) => {
   return (
-    <div onClick={clickHandler} css={indicatorCss(isSelected)}>
+    <ClickableButton onClick={clickHandler} css={indicatorCss(isSelected)}>
       {isSelected}
-    </div>
+    </ClickableButton>
   );
 };
 

--- a/src/components/recruit/JobGroupSection.tsx
+++ b/src/components/recruit/JobGroupSection.tsx
@@ -7,6 +7,7 @@ import { POSITION_TYPE_LABEL, PositionType } from './contstants';
 import { sectionCss, sectionHeadingCss } from './Recurit.style';
 import { ClickableLink } from '../common/Clickable';
 import { ArrowIcon } from '../common/icons';
+import { POSITION_TYPE } from '../recruit-detail/constants';
 
 const positionTypes = Object.keys(POSITION_TYPE_LABEL) as PositionType[];
 
@@ -19,10 +20,7 @@ export default function JobGroupSection() {
       </div>
       <ul css={jobGroupFlexBox}>
         {positionTypes.map(key => (
-          <ClickableLink
-            key={`job-group-${key}`}
-            href={`/recurit/${POSITION_TYPE_LABEL[key].toLowerCase()}`}
-          >
+          <ClickableLink key={`job-group-${key}`} href={`/recruit/${POSITION_TYPE[key]}`}>
             <li css={jobGroupItem}>
               {POSITION_TYPE_LABEL[key]}
               <span>

--- a/src/components/recruit/contstants.ts
+++ b/src/components/recruit/contstants.ts
@@ -141,7 +141,7 @@ export const POSITION_TYPE_LABEL = {
   DESIGN: 'UIUX DESIGN',
   IOS: 'iOS',
   ANDROID: 'ANDROID',
-  FRONTEND: 'FRONTEND',
+  WEB: 'WEB',
   SERVER: 'SERVER',
 } as const;
 export type PositionType = keyof typeof POSITION_TYPE_LABEL;


### PR DESCRIPTION
## 작업 내용
- 기존 frontend 텍스트를 web으로 변경합니다.
- clickablebutton을 recruit-detail에 적용합니다.

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷
<img width="1288" alt="스크린샷 2023-03-06 오전 2 55 09" src="https://user-images.githubusercontent.com/59507527/222977379-c7ae6b46-3d03-4c75-9f28-94f83bc67243.png"> 

<img width="1288" alt="스크린샷 2023-03-06 오전 2 55 16" src="https://user-images.githubusercontent.com/59507527/222977384-8327ee66-ab88-4621-ae5e-2adb4e89dd6c.png">
