### PR TITLE
남은 날짜 계산 및 로직 적용

### DIFF
--- a/src/components/common/ApplySection/ApplySection.tsx
+++ b/src/components/common/ApplySection/ApplySection.tsx
@@ -1,6 +1,7 @@
 import { css, Interpolation, Theme } from '@emotion/react';
 
 import { NOTION_RECRUIT_PATH } from '~/constants/common';
+import useIsInProgress from '~/hooks/use-is-in-progress';
 import { colors, mediaQuery } from '~/styles/constants';
 import { section36HeadingCss, sectionSmallCss } from '~/styles/css';
 
@@ -11,6 +12,8 @@ interface Props {
 }
 
 export default function ApplySection({ wrapperCss }: Props) {
+  const { isInProgress } = useIsInProgress();
+
   return (
     <section css={[sectionCss, wrapperCss]}>
       <small css={smallCss}>APPLY</small>
@@ -19,14 +22,19 @@ export default function ApplySection({ wrapperCss }: Props) {
         <br />
         디프만 13기 멤버가 되고 싶다면
       </h2>
-      <ClickableLink
-        css={linkCss}
-        href={NOTION_RECRUIT_PATH}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        바로 지원하기
-      </ClickableLink>
+
+      {isInProgress ? (
+        <ClickableLink
+          css={linkCss}
+          href={NOTION_RECRUIT_PATH}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          바로 지원하기
+        </ClickableLink>
+      ) : (
+        <button css={disabledButtonCss}>모집 마감</button>
+      )}
     </section>
   );
 }
@@ -62,6 +70,23 @@ const linkCss = css`
   font-size: 20px;
   line-height: 24px;
   color: ${colors.gray100};
+
+  ${mediaQuery('xs')} {
+    padding: 18px 60px;
+    font-size: 16px;
+    line-height: 19px;
+  }
+`;
+
+const disabledButtonCss = css`
+  border-radius: 2px;
+  padding: 16px 98px;
+  background-color: ${colors.gray500};
+
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 24px;
+  color: ${colors.white};
 
   ${mediaQuery('xs')} {
     padding: 18px 60px;

--- a/src/components/common/GNB/GNB.tsx
+++ b/src/components/common/GNB/GNB.tsx
@@ -1,23 +1,25 @@
 import { css } from '@emotion/react';
 
+import useIsInProgress from '~/hooks/use-is-in-progress';
 import useMediaQuery from '~/hooks/use-media-query';
 
-import { NAV_HEIGHT } from './constants';
+import { ANCHORS_HEIGHT, NAV_HEIGHT } from './constants';
 import DesktopAnchorSection from './DesktopAnchorSection';
 import MobileAnchorSection from './MobileAnchorSection';
 import RecrutingBanner from './RecrutingBanner';
 
 export default function GNB() {
   const isMobile = useMediaQuery('xs');
+  const { isInProgress } = useIsInProgress();
 
   return (
     <>
       <nav css={navCss}>
-        <RecrutingBanner />
+        {isInProgress && <RecrutingBanner />}
         {isMobile ? <MobileAnchorSection /> : <DesktopAnchorSection />}
       </nav>
 
-      <div css={scrollRemainerCss} />
+      <div css={scrollRemainerCss(isInProgress ? NAV_HEIGHT : ANCHORS_HEIGHT)} />
     </>
   );
 }
@@ -30,6 +32,6 @@ const navCss = css`
   width: 100vw;
 `;
 
-const scrollRemainerCss = css`
-  height: ${NAV_HEIGHT}px;
+const scrollRemainerCss = (height: number) => css`
+  height: ${height}px;
 `;

--- a/src/components/recruit/HeaderSection.tsx
+++ b/src/components/recruit/HeaderSection.tsx
@@ -1,20 +1,30 @@
 import Image from 'next/image';
 import { css } from '@emotion/react';
 
+import useIsInProgress from '~/hooks/use-is-in-progress';
 import { colors, mediaQuery } from '~/styles/constants';
 
 import { BigArrowIcon } from '../home/BigArrowIcon';
 
 export default function HeaderSection() {
+  const { remainDay, isInProgress } = useIsInProgress();
+
   return (
     <section css={headerCss}>
       <div css={headImageWrapperCss}>
-        <div css={headingCss}>
-          <h1>서류 접수 마감까지</h1>
-          <em>
-            <h1>D-7</h1>
-          </em>
-        </div>
+        {isInProgress ? (
+          <div css={headingCss}>
+            <h1>서류 접수 마감까지</h1>
+            <em>
+              <h2>D-{remainDay}</h2>
+            </em>
+          </div>
+        ) : (
+          <div css={headingCss}>
+            <h1>서류 접수 마감</h1>
+          </div>
+        )}
+
         <Image
           fill
           src="/images/recruit/home.webp"

--- a/src/constants/common/common.ts
+++ b/src/constants/common/common.ts
@@ -8,8 +8,9 @@ export const BASE_URL = 'https://www.depromeet.com';
 export const NOTION_RECRUIT_PATH =
   'https://depromeet.notion.site/DEPROMEET-13th-f1e931cf073e43c4aeca44a4521b44be';
 
-export const START_DATE = '2022-08-21T15:00:00.000Z';
-export const END_DATE = '2022-09-02T14:59:59.000Z';
+// NOTE: UTC 타임존에 맞추기 위해 9시간을 뺌
+export const START_DATE = '2023-03-05T19:00:00.000Z';
+export const END_DATE = '2023-03-12T14:59:59.000Z';
 
-// export const START_DATE = '2022-08-18T22:21:59.000Z'; // test
-// export const END_DATE = '2022-08-21T20:00:00.000Z'; // test
+// export const START_DATE = '2023-08-18T22:21:59.000Z'; // test
+// export const END_DATE = '2023-03-04T20:00:00.000Z'; // test

--- a/src/constants/common/index.ts
+++ b/src/constants/common/index.ts
@@ -1,18 +1,2 @@
-export {
-  BASE_URL,
-  END_DATE,
-  GA_ID,
-  HOTJAR_ID,
-  IS_PRODUCTION,
-  NOTION_RECRUIT_PATH,
-  START_DATE,
-} from './common';
-export {
-  DEPROMEET_BEHANCE,
-  DEPROMEET_EMAIL,
-  DEPROMEET_FACEBOOK,
-  DEPROMEET_GITHUB,
-  DEPROMEET_INSTAGRAM,
-  DEPROMEET_MEDIUM,
-  KAKAO_PLUS_FRIEND,
-} from './depromeet';
+export * from './common';
+export * from './depromeet';

--- a/src/hooks/use-is-in-progress/use-is-in-progress.ts
+++ b/src/hooks/use-is-in-progress/use-is-in-progress.ts
@@ -1,27 +1,31 @@
 import { END_DATE, START_DATE } from '~/constants/common';
 
-const RECRUIT_STATE = {
-  PREVIOUS: 'PREVIOUS',
-  IN_PROGRESS: 'IN_PROGRESS',
-  FINISH: 'FINISH',
-};
+type RecruitState = 'PREVIOUS' | 'IN_PROGRESS' | 'FINISH';
+
+const 하루 = 1000 * 60 * 60 * 24;
 
 export default function useIsInProgress() {
   const startDate = new Date(START_DATE);
   const endDate = new Date(END_DATE);
 
-  const getCurrentState = () => {
-    const current = new Date();
+  const getCurrentState = (): RecruitState => {
+    const currentDate = new Date();
 
-    if (startDate > current) return RECRUIT_STATE.PREVIOUS;
-    if (endDate < current) return RECRUIT_STATE.FINISH;
+    if (startDate > currentDate) return 'PREVIOUS';
+    if (endDate < currentDate) return 'FINISH';
 
-    return RECRUIT_STATE.IN_PROGRESS;
+    return 'IN_PROGRESS';
   };
 
-  const isInProgress = () => {
-    return getCurrentState() === RECRUIT_STATE.IN_PROGRESS;
+  const getRemainDay = (): number => {
+    const currentDate = new Date();
+    const diffMs = Math.abs(endDate.getTime() - currentDate.getTime());
+    const remainDay = Math.round(diffMs / 하루);
+    return remainDay;
   };
 
-  return isInProgress;
+  const isInProgress = getCurrentState() === 'IN_PROGRESS';
+  const remainDay = getRemainDay();
+
+  return { isInProgress, remainDay };
 }


### PR DESCRIPTION
## 작업 내용

- `useIsInProgress`에서 남은 날짜도 제공할 수 있게 했어요
  - 모집 헤더에서 사용했어요

- 모집 날짜 상수를 변경했어요
  - UTC 기준으로 9시간을 빼서 계산했어요 (이렇게 하는게 맞나 .. 싶어서 대윤님이 나중에 수정해주시면 감사하겠습니다!!)
  - 모집이 끝났을 경우 GNB의 배너 제거, Apply Section의 링크 비활성화, 모집 페이지 헤딩 변경을 해요

## 스크린샷


![스크린샷 2023-03-06 오전 4 49 55](https://user-images.githubusercontent.com/26461307/222982550-fe15cc04-1c14-4a95-bc81-62a9c20402fd.png)
![스크린샷 2023-03-06 오전 4 49 48](https://user-images.githubusercontent.com/26461307/222982552-8757269b-e96c-4d23-a20f-f9ddff679b46.png)
![스크린샷 2023-03-06 오전 4 49 42](https://user-images.githubusercontent.com/26461307/222982554-22de16f4-050c-4298-80a6-41184cfe49c4.png)
