### PR TITLE
fix: 프로젝트 리스트 hover shadow, 클릭 영역 확장

### DIFF
--- a/src/components/project/ProjectItem/ProjectItem.tsx
+++ b/src/components/project/ProjectItem/ProjectItem.tsx
@@ -19,22 +19,25 @@ export default function ProjectItem({ project }: Props) {
 
   return (
     <m.article css={wrapperCss} variants={defaultFadeInUpVariants}>
-      <Image
-        src={`/projects/${project.thumbnail}`}
-        alt={project.title}
-        fill
-        css={thumbnailCss}
-        quality={100}
-      />
-      <div css={gradientCss} />
-      <div css={isMobile ? mobileContentsWrapperCss : contentsWrapperCss}>
-        <span>{project.generation}기</span>
-        <h3>{project.title}</h3>
-        <p>{project.catchphrase}</p>
-        <ClickableLink href={`/project/${project.title}`} css={detailLinkCss}>
-          <ArrowIcon width={24} height={24} direction="right" />
-        </ClickableLink>
-      </div>
+      <ClickableLink href={`/project/${project.title}`}>
+        <Image
+          src={`/projects/${project.thumbnail}`}
+          alt={project.title}
+          fill
+          priority
+          css={thumbnailCss}
+          quality={100}
+          placeholder="blur"
+          blurDataURL={`/projects/${project.thumbnail}`}
+        />
+        <div css={gradientCss} />
+        <div css={isMobile ? mobileContentsWrapperCss : contentsWrapperCss}>
+          <span>{project.generation}기</span>
+          <h3>{project.title}</h3>
+          <p>{project.catchphrase}</p>
+          <ArrowIcon width={24} height={24} direction="right" css={detailLinkCss} />
+        </div>
+      </ClickableLink>
     </m.article>
   );
 }

--- a/src/components/project/ProjectItem/ProjectItem.tsx
+++ b/src/components/project/ProjectItem/ProjectItem.tsx
@@ -52,7 +52,6 @@ const wrapperCss = css`
 const gradientCss = css`
   position: absolute;
   bottom: 0;
-  background: linear-gradient(180deg, #121212 0%, rgba(18, 18, 18, 0) 100%);
   transform: rotate(-180deg);
   width: 100%;
   height: 172px;
@@ -66,6 +65,7 @@ const thumbnailCss = css`
 const contentsWrapperCss = css`
   opacity: 0;
   &:hover {
+    background: linear-gradient(180deg, #121212 0%, rgba(18, 18, 18, 0) 100%);
     opacity: 1;
   }
   width: 100%;

--- a/src/components/project/ProjectItem/ProjectItem.tsx
+++ b/src/components/project/ProjectItem/ProjectItem.tsx
@@ -58,6 +58,10 @@ const gradientCss = css`
   transform: rotate(-180deg);
   width: 100%;
   height: 172px;
+
+  ${mediaQuery('xs')} {
+    background: linear-gradient(180deg, #121212 0%, rgba(18, 18, 18, 0) 100%);
+  }
 `;
 
 const thumbnailCss = css`


### PR DESCRIPTION
## 작업 내용

<img width="1592" alt="Screenshot 2023-03-06 at 11 28 01 PM" src="https://user-images.githubusercontent.com/80014673/223138357-f0276a72-f0ff-4833-8767-a75b7fcabba3.png">

<img width="1576" alt="Screenshot 2023-03-06 at 11 28 48 PM" src="https://user-images.githubusercontent.com/80014673/223138566-f4ffed8b-6b9f-4868-ac40-8700e4626835.png">

https://www.notion.so/depromeet/DEPROMEET-the-13th-a1705397a558404789fb3a14c15be132?pvs=4

- hover 안했을 때 default로 쉐도우를 빼고 hover 했을 때 쉐도우를 넣었습니다
- 프로젝트 상세 clickableLink를 상위 depth로 올렸습니다.

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
