### PR TITLE
D-day 설정 및 커스텀 커서 스크롤 대응

### DIFF
--- a/src/components/common/CustomCursor/CustomCursor.tsx
+++ b/src/components/common/CustomCursor/CustomCursor.tsx
@@ -23,7 +23,7 @@ function CustomCursor() {
     function handleMouseMove(e: MouseEvent) {
       cursorRef.current?.setAttribute(
         'style',
-        `top: ${e.pageY}px;` + `left: ${e.pageX}px; display: inline`
+        `top: ${e.clientY}px;` + `left: ${e.clientX}px; display: inline`
       );
     }
     document.addEventListener('mousemove', handleMouseMove);
@@ -53,7 +53,7 @@ const cursorCss = css`
   background-size: contain;
   width: 32px;
   height: 32px;
-  position: absolute;
+  position: fixed;
   pointer-events: none;
   z-index: 9999;
 

--- a/src/components/recruit/HeaderSection.tsx
+++ b/src/components/recruit/HeaderSection.tsx
@@ -12,18 +12,18 @@ export default function HeaderSection() {
   return (
     <section css={headerCss}>
       <div css={headImageWrapperCss}>
-        {isInProgress ? (
-          <div css={headingCss}>
-            <h1>서류 접수 마감까지</h1>
-            <em>
-              <h2>D-{remainDay}</h2>
-            </em>
-          </div>
-        ) : (
-          <div css={headingCss}>
+        <div css={headingCss}>
+          {isInProgress ? (
+            <>
+              <h1>서류 접수 마감까지</h1>
+              <em>
+                <h2>D-{remainDay === 0 ? 'Day' : remainDay}</h2>
+              </em>
+            </>
+          ) : (
             <h1>서류 접수 마감</h1>
-          </div>
-        )}
+          )}
+        </div>
 
         <Image
           fill


### PR DESCRIPTION
## 작업 내용

- 모집 마감 날짜가 0일 경우 `D-Day`가 노출되도록 했어요

- 네이버 deview 웹을 보고, 커스텀 커서 동작에 영감을 얻었어요
  https://deview.kr/2023

그래서 스크롤 시 위치를 고정(fixed)하고, 움직임을 client 좌표로 변경했습니당

https://user-images.githubusercontent.com/26461307/224474663-921dec7d-695f-4150-8f96-e6fde3f95571.mov


## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
