### PR TITLE
14기 모집문구수정

### DIFF
--- a/src/components/common/ApplySection/ApplySection.tsx
+++ b/src/components/common/ApplySection/ApplySection.tsx
@@ -2,6 +2,7 @@ import { css, Interpolation, Theme } from '@emotion/react';
 
 import { NOTION_RECRUIT_PATH } from '~/constants/common';
 import useIsInProgress from '~/hooks/use-is-in-progress';
+import { RecruitState } from '~/hooks/use-is-in-progress/use-is-in-progress';
 import { colors, mediaQuery } from '~/styles/constants';
 import { section36HeadingCss, sectionSmallCss } from '~/styles/css';
 
@@ -11,17 +12,29 @@ interface Props {
   wrapperCss?: Interpolation<Theme>;
 }
 
+const applyMessageObj: Record<RecruitState, { h1: string; button: string }> = {
+  PREVIOUS: {
+    h1: '14기는 아직 준비중',
+    button: '모집 예정',
+  },
+  IN_PROGRESS: {
+    h1: '이제 여러분 차례예요! \n디프만 13기 멤버가 되고 싶다면',
+    button: '바로 지원하기',
+  },
+  FINISH: {
+    h1: '이제 여러분 차례예요! \n디프만 13기 멤버가 되고 싶다면',
+    button: '모집 마감',
+  },
+};
+
 export default function ApplySection({ wrapperCss }: Props) {
-  const { isInProgress } = useIsInProgress();
+  const { isInProgress, progressState } = useIsInProgress();
+  const applyMessage = applyMessageObj[progressState];
 
   return (
     <section css={[sectionCss, wrapperCss]}>
       <small css={smallCss}>APPLY</small>
-      <h2 css={headingCss}>
-        이제 여러분 차례예요!
-        <br />
-        디프만 13기 멤버가 되고 싶다면
-      </h2>
+      <h2 css={headingCss}>{applyMessage.h1}</h2>
 
       {isInProgress ? (
         <ClickableLink
@@ -30,10 +43,10 @@ export default function ApplySection({ wrapperCss }: Props) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          바로 지원하기
+          {applyMessage.button}
         </ClickableLink>
       ) : (
-        <button css={disabledButtonCss}>모집 마감</button>
+        <button css={disabledButtonCss}>{applyMessage.button}</button>
       )}
     </section>
   );

--- a/src/constants/common/common.ts
+++ b/src/constants/common/common.ts
@@ -9,8 +9,8 @@ export const NOTION_RECRUIT_PATH =
   'https://depromeet.notion.site/DEPROMEET-13th-f1e931cf073e43c4aeca44a4521b44be';
 
 // NOTE: UTC 타임존에 맞추기 위해 9시간을 뺌
-export const START_DATE = '2023-03-05T19:00:00.000Z';
-export const END_DATE = '2023-03-12T14:59:59.000Z';
+export const START_DATE = '2023-10-02T19:00:00.000Z';
+export const END_DATE = '2023-10-08T14:59:59.000Z';
 
 // export const START_DATE = '2023-08-18T22:21:59.000Z'; // test
 // export const END_DATE = '2023-03-04T20:00:00.000Z'; // test

--- a/src/hooks/use-is-in-progress/use-is-in-progress.ts
+++ b/src/hooks/use-is-in-progress/use-is-in-progress.ts
@@ -1,6 +1,6 @@
 import { END_DATE, START_DATE } from '~/constants/common';
 
-type RecruitState = 'PREVIOUS' | 'IN_PROGRESS' | 'FINISH';
+export type RecruitState = 'PREVIOUS' | 'IN_PROGRESS' | 'FINISH';
 
 const 하루 = 1000 * 60 * 60 * 24;
 

--- a/src/hooks/use-is-in-progress/use-is-in-progress.ts
+++ b/src/hooks/use-is-in-progress/use-is-in-progress.ts
@@ -25,7 +25,8 @@ export default function useIsInProgress() {
   };
 
   const isInProgress = getCurrentState() === 'IN_PROGRESS';
+  const progressState = getCurrentState();
   const remainDay = getRemainDay();
 
-  return { isInProgress, remainDay };
+  return { isInProgress, progressState, remainDay };
 }


### PR DESCRIPTION
## 작업 내용

- useIsInProgress의 RecruitState에 따른 모집 기간 문구 수정
- 14기 임시 모집기간 적용

## 스크린샷

사용하는 곳

- 메인 페이지 하단
- 13기 모집 안내 페이지 하단

<img width="791" alt="스크린샷 2023-09-02 오후 5 01 09" src="https://github.com/depromeet/www.depromeet.com/assets/71386219/d991e11a-6fab-454c-bef5-449b9c0dda78">



