### PR TITLE
[Fix] section title 엔터 안먹는 문제 수정

### DIFF
--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -40,6 +40,7 @@ const titleCss = (theme: Theme) => css`
   margin-top: 16px;
   text-align: center;
   text-align: center;
+  white-space: pre-line;
 `;
 
 const descriptionCss = (theme: Theme) => css`


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
<img width="795" alt="스크린샷 2023-09-13 오전 12 13 51" src="https://github.com/depromeet/www.depromeet.com/assets/49177223/b5344f5d-6d4b-4a0c-bb86-4077574fc98a">

`section-title` branch에서 발생한 enter가 안되는 문제를 해결했습니다. 

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
<img width="1497" alt="스크린샷 2023-09-13 오전 12 14 33" src="https://github.com/depromeet/www.depromeet.com/assets/49177223/9edf179d-c87d-49a4-9b87-b6591ea59edd">

## 레퍼런스
- [참고 링크](https://velog.io/@leemember/React-Props%EB%A1%9C-%EC%A0%84%EB%8B%AC%EB%90%98%EB%8A%94-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%A4%84%EB%B0%94%EA%BF%88-%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95-CSS-%ED%85%8D%EC%8A%A4%ED%8A%B8-%EB%91%90-%EC%A4%84%EA%B9%8C%EC%A7%80%EB%A7%8C-%EB%B3%B4%EC%97%AC%EC%A7%80%EA%B3%A0-%EB%82%98%EB%A8%B8%EC%A7%80%EB%8A%94-..-.%EC%B2%98%EB%A6%AC)
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
