### PR TITLE
[Style] SectionTitle 컴포넌트 스타일 수정

### DIFF
--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -17,7 +17,7 @@ export function SectionTitle({ label, title, description, ...layoutProps }: Sect
     <div css={layoutCss} {...layoutProps}>
       <h4 css={labelCss}>{label}</h4>
       <h2 css={titleCss}>{title}</h2>
-      {<p css={descriptionCss}>{description}</p>}
+      {description && <p css={descriptionCss}>{description}</p>}
     </div>
   );
 }

--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -15,8 +15,8 @@ interface SectionTitleProps {
 export function SectionTitle({ label, title, description, ...layoutProps }: SectionTitleProps) {
   return (
     <div css={layoutCss} {...layoutProps}>
-      <h4 css={labelCss}>{label}</h4>
-      <h2 css={titleCss}>{title}</h2>
+      {label && <h4 css={labelCss}>{label}</h4>}
+      {title && <h2 css={titleCss}>{title}</h2>}
       {description && <p css={descriptionCss}>{description}</p>}
     </div>
   );

--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -17,7 +17,7 @@ export function SectionTitle({ label, title, description, ...layoutProps }: Sect
     <div css={layoutCss} {...layoutProps}>
       <h4 css={labelCss}>{label}</h4>
       <h2 css={titleCss}>{title}</h2>
-      <p css={descriptionCss}>{description}</p>
+      {<p css={descriptionCss}>{description}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## 작업 내용
- SectionTitle 아래 공백이 이상하게 많은 것 같아 확인해보니,
설명 props를 넘기지 않아도 dom이 렌더링되어 공간을 차지하는 문제였습니다. 
- 설명 props가 있을 때만 돔을 렌더링하게해서 수정했습니다. 
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷

### as is
<img width="370" alt="image" src="https://github.com/depromeet/www.depromeet.com/assets/49177223/f5b9d46f-2b5a-4897-9cf4-66788dfbcf5c">

### to be
<img width="574" alt="image" src="https://github.com/depromeet/www.depromeet.com/assets/49177223/1c8fc3f2-1c2f-4ce9-b52f-9870aa1a5118">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
