### PR TITLE
[Fix] 일정 대문자로 변경

### DIFF
--- a/src/components/ScheduleSection/ScheduleSection.tsx
+++ b/src/components/ScheduleSection/ScheduleSection.tsx
@@ -62,6 +62,7 @@ const topLabelContainerCss = (theme: Theme) => css`
     flex: 1;
     padding: 6px 0;
     color: ${theme.colors.gray200};
+    text-transform: uppercase;
   }
 
   ${mediaQuery('mobile')} {


### PR DESCRIPTION
## 작업 내용
QA 사항 중 
3.  14기 일정 티켓 타이틀 영문 대문자로 변경바랍니다! (메인 페이지, 모집 안내 페이지에도 일괄 적용)

![image](https://github.com/depromeet/www.depromeet.com/assets/49177223/61c449a1-2cf9-4e6e-b92c-dee6175c770e)
