### PR TITLE
[feat]: 메인 페이지 최하단 이미지(표지만) 너비 수정

### DIFF
--- a/src/components/AboutInfo/AboutInfo.tsx
+++ b/src/components/AboutInfo/AboutInfo.tsx
@@ -3,7 +3,7 @@ import { css, Theme } from '@emotion/react';
 
 import { commonLayoutCss } from '~/styles/layout';
 import { mediaQuery } from '~/styles/media';
-import { pxToRem } from '~/styles/typo';
+import { pxToRem } from '~/styles/style.utils';
 
 export function AboutInfo() {
   return (

--- a/src/components/Main/SignImageSection.tsx
+++ b/src/components/Main/SignImageSection.tsx
@@ -2,29 +2,23 @@ import Image from 'next/image';
 import { css } from '@emotion/react';
 
 import { commonLayoutCss } from '~/styles/layout';
-import { mediaQuery } from '~/styles/media';
+import { autoImageRatio } from '~/styles/style.utils';
 
 export function SignImageSection() {
   return (
     <section css={[commonLayoutCss, layoutCss]}>
-      <Image src="/images/sign/main.png" fill alt="DPM 14th" />
+      <div css={imageCss}>
+        <Image src="/images/sign/main.png" fill quality={100} alt="DPM 14th" />
+      </div>
     </section>
   );
 }
 
 const layoutCss = css`
-  position: relative;
   width: 100%;
-  height: 356px;
-  img {
-    width: 100%;
-    object-fit: contain;
-  }
+  height: 100%;
+`;
 
-  ${mediaQuery('tablet')} {
-    height: 262px;
-  }
-  ${mediaQuery('mobile')} {
-    height: 122px;
-  }
+const imageCss = css`
+  ${autoImageRatio(959, 356)};
 `;

--- a/src/styles/style.utils.ts
+++ b/src/styles/style.utils.ts
@@ -1,0 +1,1 @@
+export const pxToRem = (px: number, base = 16) => `${px / base}rem`;

--- a/src/styles/style.utils.ts
+++ b/src/styles/style.utils.ts
@@ -1,1 +1,10 @@
+import { css } from '@emotion/react';
+
 export const pxToRem = (px: number, base = 16) => `${px / base}rem`;
+
+export const autoImageRatio = (width: number, height: number) => css`
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: calc(${height} / ${width} * 100%);
+`;

--- a/src/styles/typo.ts
+++ b/src/styles/typo.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-export const pxToRem = (px: number, base = 16) => `${px / base}rem`;
+import { pxToRem } from '~/styles/style.utils';
 
 export const typos = {
   pretendard: {


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
- 화면 크기에 맞게 이미지 비율은 유지하면서 크기를 조절해주는 utils함수 추가 ([feat: autoImageRatio](https://github.com/depromeet/www.depromeet.com/commit/646b803360d09dd3cf075fa2394313ce5ec0aa4c))

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->



https://github.com/depromeet/www.depromeet.com/assets/71386219/ed09be33-ab4b-4b93-a64e-56f2e6d7138c

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

https://www.notion.so/depromeet/d55aeebae34c4cc6aeedb2606110593a?pvs=4
