### PR TITLE
fix: supportThumbnail 컨텐츠 노출 hover 범위를 article로 수정

### DIFF
--- a/src/components/Supports/SupportThumbnail.tsx
+++ b/src/components/Supports/SupportThumbnail.tsx
@@ -78,6 +78,9 @@ const articleCss = css`
   &:hover img {
     filter: blur(5px) brightness(0.4);
   }
+  &:hover > div {
+    opacity: 1;
+  }
 `;
 
 const imageArticleCss = css`
@@ -98,10 +101,6 @@ const contentsCss = css`
   justify-content: space-between;
   transition: opacity 0.3s ease;
   opacity: 0;
-
-  &:hover {
-    opacity: 1;
-  }
 `;
 
 const linkContainerCss = css`


### PR DESCRIPTION
## 작업 내용

#331 

SupportThumbnail 컴포넌트의 articleCss에서 hover시 blur 효과를 적용해주고 있는데요,
blur는 적용되지만 contentsCss가 articleCss의 padding 영역만큼을 커버하지 못하여 일부 구간에서는 blur만 적용되고 컨텐츠 텍스트가 노출되지 않는 현상이 발생합니다.

articleCss에서 자손선택자로 div에 hover시 opacity : 1을 적용하여 컴포넌트 영역 내에서 blur효과와 컨텐츠 텍스트 노출이 함께 이루어지도록 수정하였습니다.



## 스크린샷

## ASIS
https://github.com/depromeet/www.depromeet.com/assets/82137004/0b6609b7-d757-4b80-8fb0-f08eea5e3136

## TOBE
https://github.com/depromeet/www.depromeet.com/assets/82137004/21517bcc-d24f-4544-b015-479bb9b83d67

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
