### PR TITLE
[refactor]: formatSingleDigit 선행 조건 강화 및 테스트 코드 수정

### DIFF
--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -4,23 +4,26 @@ import { formatSingleDigit } from '~/utils/format';
 
 describe('format 관련 유틸 함수', () => {
   describe('formatSingleDigit 함수 테스트', () => {
-    it('🟢 한 자리 숫자에 대해 선행 0이 있는 문자열을 반환한다. ', () => {
-      expect(formatSingleDigit(0)).toBe('00');
+    it('🟢 한 자리 양수에 대해 선행 0이 있는 문자열을 반환한다. ', () => {
       expect(formatSingleDigit(5)).toBe('05');
       expect(formatSingleDigit(9)).toBe('09');
     });
-    it('🟢 두 자리 숫자에 대해 숫자를 문자열로 반환한다.', () => {
+    it('🟢 "0"에 대해 선행0이 있는 문자열을 반환한다.', () => {
+      expect(formatSingleDigit(0)).toBe('00');
+    });
+    it('🟢 두 자리 이상의 숫자에 대해 해당 숫자를 문자열로 반환한다.', () => {
       expect(formatSingleDigit(10)).toBe('10');
       expect(formatSingleDigit(25)).toBe('25');
       expect(formatSingleDigit(99)).toBe('99');
+      expect(formatSingleDigit(100)).toBe('100');
+      expect(formatSingleDigit(9999999)).toBe('9999999');
     });
-    // TODO: @kimyouknow 아래 테스트 케이스에 맞게 formatSingleDigit 수정하기
-    it.todo('🟢 음수는 그대로 반환한다.', () => {
+
+    it('🟢 음수는 그대로 반환한다.', () => {
       expect(formatSingleDigit(-5)).toBe('-5');
       expect(formatSingleDigit(-9)).toBe('-9');
     });
-    // TODO: @kimyouknow 아래 테스트 케이스에 맞게 formatSingleDigit 수정하기
-    it.todo('🟢 정수가 아닌 숫자는 그대로 반환한다.', () => {
+    it('🟢 정수가 아닌 숫자는 그대로 반환한다.', () => {
       expect(formatSingleDigit(5.5)).toBe('5.5');
       expect(formatSingleDigit(9.9)).toBe('9.9');
     });

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -37,6 +37,9 @@ describe('format 관련 유틸 함수', () => {
       expect(() => formatSingleDigit(9.9)).toThrowError(
         '잘못된 입력입니다. 양수 정수만 처리 가능합니다.'
       );
+      expect(() => formatSingleDigit(Infinity)).toThrowError(
+        '잘못된 입력입니다. 양수 정수만 처리 가능합니다.'
+      );
     });
   });
 });

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -7,6 +7,7 @@ describe('format 관련 유틸 함수', () => {
     it('🟢 한 자리 양수에 대해 선행 0이 있는 문자열을 반환한다. ', () => {
       expect(formatSingleDigit(5)).toBe('05');
       expect(formatSingleDigit(9)).toBe('09');
+      expect(formatSingleDigit(1.0)).toBe('01');
     });
     it('🟢 "0"에 대해 선행0이 있는 문자열을 반환한다.', () => {
       expect(formatSingleDigit(0)).toBe('00');
@@ -18,14 +19,24 @@ describe('format 관련 유틸 함수', () => {
       expect(formatSingleDigit(100)).toBe('100');
       expect(formatSingleDigit(9999999)).toBe('9999999');
     });
-
-    it('🟢 음수는 그대로 반환한다.', () => {
-      expect(formatSingleDigit(-5)).toBe('-5');
-      expect(formatSingleDigit(-9)).toBe('-9');
+    it('🔴 음수에 대해 에러를 반환한다..', () => {
+      expect(() => formatSingleDigit(-5)).toThrowError(
+        '잘못된 입력입니다. 양수 정수만 처리 가능합니다.'
+      );
+      expect(() => formatSingleDigit(-9)).toThrowError(
+        '잘못된 입력입니다. 양수 정수만 처리 가능합니다.'
+      );
+      expect(() => formatSingleDigit(-9.1)).toThrowError(
+        '잘못된 입력입니다. 양수 정수만 처리 가능합니다.'
+      );
     });
-    it('🟢 정수가 아닌 숫자는 그대로 반환한다.', () => {
-      expect(formatSingleDigit(5.5)).toBe('5.5');
-      expect(formatSingleDigit(9.9)).toBe('9.9');
+    it('🔴 정수가 아닌 숫자에 대해 에러를 반환한다.', () => {
+      expect(() => formatSingleDigit(5.5)).toThrowError(
+        '잘못된 입력입니다. 양수 정수만 처리 가능합니다.'
+      );
+      expect(() => formatSingleDigit(9.9)).toThrowError(
+        '잘못된 입력입니다. 양수 정수만 처리 가능합니다.'
+      );
     });
   });
 });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,4 +1,12 @@
 export function formatSingleDigit(number: number) {
+  if (number < 0) {
+    return number.toString();
+  }
+
+  if (!Number.isInteger(number)) {
+    return number.toString();
+  }
+
   if (number < 10) {
     return '0' + number;
   }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,10 +1,6 @@
 export function formatSingleDigit(number: number) {
-  if (number < 0) {
-    return number.toString();
-  }
-
-  if (!Number.isInteger(number)) {
-    return number.toString();
+  if (number < 0 || !Number.isInteger(number)) {
+    throw new Error('잘못된 입력입니다. 양수 정수만 처리 가능합니다.');
   }
 
   if (number < 10) {


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

테스트 코드를 짜다보니까 formatSingleDigit에서 예외 처리가 안 된걸 찾음!

아래 케이스를 대응해줬다~

- 음수가 입력 값으로 들어왔을 때
- 정수가 아닌 숫자가 입력 값으로 들어왔을 때

**고민 했던 부분**

`formatSingleDigit`이라는 네이밍을 보면 음수와 정수가 아닌 숫자를 그대로 반환하는게 아니라 `throw Error` 혹은 `console.error`처럼 개발자에게 잘못된 사용이라고 알려줘야 한다고 생각했어요



## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
https://github.com/depromeet/www.depromeet.com/issues/335