### PR TITLE
feat: 블로그 게시글 썸네일 구현

### DIFF
--- a/src/components/Blog/BlogPostThumbnail.tsx
+++ b/src/components/Blog/BlogPostThumbnail.tsx
@@ -1,0 +1,156 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { css, Theme } from '@emotion/react';
+import { m } from 'framer-motion';
+
+import { ArrowIcon } from '~/components/Icons';
+import { defaultFadeInVariants } from '~/constant/motion';
+import { colors } from '~/styles/colors';
+import { mediaQuery } from '~/styles/media';
+
+export type Link = {
+  type: 'MEDIUM';
+  href: string;
+};
+
+type ThumbnailProps = {
+  title: string;
+  date: string;
+  img: string;
+  links?: Link[];
+  showInfoDefault?: boolean;
+  backgroundShow?: boolean;
+};
+
+export function BlogPostThumbnail({ title, date, img, links }: ThumbnailProps) {
+  return (
+    <m.article
+      css={articleCss}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      whileHover="hover"
+      variants={defaultFadeInVariants}
+    >
+      <section css={gradientCss} />
+      <Image css={imageCss} src={img} alt={title} fill quality={100} />
+      <div>
+        <h1 css={titleCss} dangerouslySetInnerHTML={{ __html: title as string }} />
+        <h3 css={dateCss}>{date}</h3>
+      </div>
+      <div css={contentsCss}>
+        {links && (
+          <div css={linkContainerCss}>
+            {links.map(link => (
+              <Link key={link.type} href={link.href} css={linkCss}>
+                {link.type}
+                <ArrowIcon direction={'right'} color={colors.mint} width={16} height={16} />
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </m.article>
+  );
+}
+
+const articleCss = css`
+  position: relative;
+  width: 100%;
+  height: 208px;
+  min-width: 160px;
+  padding: 18px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: black;
+
+  ${mediaQuery('tablet')} {
+    padding: 16px;
+  }
+  ${mediaQuery('mobile')} {
+    padding: 14px;
+    height: 180px;
+    max-width: 460px;
+  }
+  @media (max-width: 400px) {
+    padding: 10px;
+  }
+  &:hover {
+    cursor: pointer;
+  }
+  &:hover > section {
+    opacity: 0;
+  }
+  &:hover > div {
+    opacity: 1;
+  }
+  &:hover img {
+    filter: blur(8px) brightness(0.4);
+  }
+`;
+
+const gradientCss = css`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%);
+`;
+
+const imageCss = css`
+  object-fit: cover;
+  object-position: center;
+  z-index: -1;
+`;
+
+const contentsCss = css`
+  transition: opacity 0.3s ease;
+  opacity: 0;
+`;
+
+const linkContainerCss = css`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+`;
+
+const linkCss = (theme: Theme) => css`
+  margin-right: 2px;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  color: ${colors.mint};
+  z-index: 10;
+  ${theme.typos.bebas.regular24}
+`;
+
+const titleCss = css`
+  position: relative;
+  font-weight: 700;
+  font-size: 1.25rem;
+  line-height: 30px;
+  color: ${colors.white};
+  z-index: 10;
+  white-space: pre-line;
+
+  ${mediaQuery('mobile')} {
+    font-size: 1rem;
+  }
+`;
+
+const dateCss = css`
+  position: relative;
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 22px;
+  color: ${colors.gray};
+  z-index: 10;
+
+  ${mediaQuery('mobile')} {
+    line-height: 20px;
+    font-size: 0.8rem;
+  }
+`;

--- a/src/components/Blog/index.ts
+++ b/src/components/Blog/index.ts
@@ -1,0 +1,2 @@
+export type { Link } from './BlogPostThumbnail';
+export { BlogPostThumbnail } from './BlogPostThumbnail';

--- a/src/components/OfflineSession/OfflineThumbnail.tsx
+++ b/src/components/OfflineSession/OfflineThumbnail.tsx
@@ -6,18 +6,12 @@ import { defaultFadeInVariants } from '~/constant/motion';
 import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
-export type Link = {
-  type: 'Behance' | 'Github' | 'Web' | 'App';
-  href: string;
-};
-
 type ThumbnailProps = {
   title: string;
   subTitle: string;
   img: string;
   description: string;
   titleTextColor: string;
-  links?: Link[];
   showInfoDefault?: boolean;
   backgroundShow?: boolean;
 };
@@ -151,7 +145,6 @@ const descriptionCss = css`
   z-index: 10;
   letter-spacing: -0.16px;
   white-space: pre-wrap;
-  z-index: 10;
 
   ${mediaQuery('mobile')} {
     line-height: 20px;

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
 import { AnimatePresence, m } from 'framer-motion';
 
+import { BlogPostThumbnail, Link } from '~/components/Blog';
 import { Intro } from '~/components/Intro';
 import { Subscribe } from '~/components/Main';
 import { SectionTitleV2 } from '~/components/SectionTitleV2';
 import { SEO } from '~/components/SEO';
-import { Thumbnail } from '~/components/Thumbnail';
-import { Link } from '~/components/Thumbnail/Thumbnail';
 import { BLOG_LIST } from '~/constant/blog';
 import { staggerHalf } from '~/constant/motion';
 import { mediaQuery } from '~/styles/media';
@@ -34,10 +33,11 @@ export default function blog() {
               variants={staggerHalf}
             >
               {BLOG_LIST.map(blog => (
-                <Thumbnail
+                <BlogPostThumbnail
                   key={blog.title}
                   img={blog.img}
                   title={blog.title}
+                  date={blog.date}
                   links={blog.links as Link[]}
                 />
               ))}
@@ -74,6 +74,8 @@ const blogContainerCss = css`
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(3, 1fr);
   gap: 12px;
+  justify-items: center;
+
   ${mediaQuery('tablet')} {
     grid-template-columns: repeat(2, 1fr);
   }


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- 블로그 게시글 썸네일을 디자인 시안에 맞게 새로 구현

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

- PC

![스크린샷 2024-04-25 오후 4 25 29](https://github.com/depromeet/www.depromeet.com/assets/45158550/1b3ac4ab-8529-41fb-a6e7-0d687365f6f6)

- mobile

![스크린샷 2024-04-25 오후 4 25 47](https://github.com/depromeet/www.depromeet.com/assets/45158550/ec4164e3-5c8b-4f8d-a073-0e4479fa0284)


## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
