### PR TITLE
[feat] 공통 Result component의 스타일 수정, main 페이지 적용

### DIFF
--- a/src/components/Result/Result.tsx
+++ b/src/components/Result/Result.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import { css } from '@emotion/react';
 
 import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
+import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
 import { ResultCardList } from './ResultCardList';
@@ -21,15 +22,24 @@ export const Result = () => {
           {isMobileSize && <br />}
           <span css={emphasis.text}>
             <div css={emphasis.imageWrapper}>
-              <Image
-                src="/images/16th/about/emphasis.png"
-                alt="성장추구형 강조"
-                width={124}
-                height={40}
-              />
+              {isMobileSize ? (
+                <Image
+                  src="/images/16th/about/emphasis.png"
+                  alt="성장추구형 강조"
+                  width={95}
+                  height={33}
+                />
+              ) : (
+                <Image
+                  src="/images/16th/about/emphasis.png"
+                  alt="성장추구형 강조"
+                  width={132}
+                  height={43}
+                />
+              )}
             </div>
           </span>
-          <span css={emphasis.text}>성장추구형</span>
+          <span css={emphasis.growText}>성장추구형</span>
           <span css={emphasis.rightText}>커뮤니티입니다.</span>
         </h1>
       </div>
@@ -55,6 +65,11 @@ const title = {
       line-height: 150%;
       text-align: center;
       height: fit-content;
+
+      ${mediaQuery('mobile')} {
+        ${theme.typosV2.pretendard.semibold18}
+        line-height: 150%;
+      }
     }
   `,
 };
@@ -65,13 +80,31 @@ const emphasis = {
   `,
   rightText: css`
     margin-left: 14px;
+
+    ${mediaQuery('mobile')} {
+      margin-left: 8px;
+    }
   `,
   text: css`
     position: relative;
   `,
+  growText: css`
+    position: relative;
+    ${theme.typosV2.pretendard.semibold26};
+
+    ${mediaQuery('mobile')} {
+      ${theme.typosV2.pretendard.semibold20}
+      line-height: 150%;
+    }
+  `,
   imageWrapper: css`
     position: absolute;
     left: -11px;
-    top: -3px;
+    top: -4px;
+
+    ${mediaQuery('mobile')} {
+      left: -6px;
+      top: -4px;
+    }
   `,
 };

--- a/src/features/Main/sections/MainResultSection.tsx
+++ b/src/features/Main/sections/MainResultSection.tsx
@@ -1,13 +1,22 @@
+import Link from 'next/link';
 import { css, Theme } from '@emotion/react';
 
+import { Icon } from '~/components/Icon/Icon';
 import { Result } from '~/components/Result';
+import { mediaQuery } from '~/styles/media';
+import { theme } from '~/styles/theme';
 
 export const MainResultSection = () => {
   return (
     <section css={layoutCss}>
       <Result />
 
-      <button>디프만 소개 보기</button>
+      <Link href={'/about'} css={button.containerCss}>
+        <div css={button.wrapperCss}>
+          디프만 소개 보기
+          <Icon icon={'ic_arrow_white'} size={24} />
+        </div>
+      </Link>
     </section>
   );
 };
@@ -21,3 +30,32 @@ const layoutCss = (theme: Theme) => css`
   align-items: center;
   background-color: ${theme.colors.white};
 `;
+
+const button = {
+  containerCss: css`
+    padding: 12px 36px;
+    border-radius: 100px;
+    background-color: black;
+  `,
+
+  wrapperCss: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    color: white;
+    ${theme.typosV2.pretendard.semibold20};
+    line-height: 150%;
+
+    ${mediaQuery('mobile')} {
+      ${theme.typosV2.pretendard.semibold16};
+      line-height: 150%;
+    }
+  `,
+
+  iconCss: css`
+    width: 24px;
+    height: 24px;
+    background-color: black;
+    border-radius: 400px;
+  `,
+};

--- a/src/features/Main/sections/MainResultSection.tsx
+++ b/src/features/Main/sections/MainResultSection.tsx
@@ -9,7 +9,10 @@ import { theme } from '~/styles/theme';
 export const MainResultSection = () => {
   return (
     <section css={layoutCss}>
-      <Result />
+      <div css={resultWrapper}>
+        <h1 css={titleCss}>생각을 현실로, 열정을 성취로</h1>
+        <Result />
+      </div>
 
       <Link href={'/about'} css={button.containerCss}>
         <div css={button.wrapperCss}>
@@ -29,6 +32,23 @@ const layoutCss = (theme: Theme) => css`
   gap: 90px;
   align-items: center;
   background-color: ${theme.colors.white};
+`;
+
+const resultWrapper = css`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  text-align: center;
+`;
+
+const titleCss = css`
+  ${theme.typosV2.pretendard.bold44};
+  line-height: 150%;
+
+  ${mediaQuery('mobile')} {
+    ${theme.typosV2.pretendard.bold28};
+    line-height: 150%;
+  }
 `;
 
 const button = {

--- a/src/features/Main/sections/MainResultSection.tsx
+++ b/src/features/Main/sections/MainResultSection.tsx
@@ -38,6 +38,7 @@ const resultWrapper = css`
   display: flex;
   flex-direction: column;
   gap: 30px;
+  width: 100%;
   text-align: center;
 `;
 

--- a/src/styles/typo.ts
+++ b/src/styles/typo.ts
@@ -155,6 +155,13 @@ export const typosV2 = {
       line-height: ${pxToRem(74)};
       letter-spacing: -0.04em;
     `,
+    bold44: css`
+      font-size: ${pxToRem(44)};
+      font-style: normal;
+      font-weight: 700;
+      line-height: ${pxToRem(53)};
+      letter-spacing: -0.04em;
+    `,
     bold32: css`
       font-size: ${pxToRem(32)};
       font-style: normal;


### PR DESCRIPTION
## 작업 내용
- 공통 result component의 스타일을 수정합니다
- 메인 페이지에 적용합니다.

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
<img width="1421" alt="스크린샷 2024-11-25 오후 9 49 05" src="https://github.com/user-attachments/assets/6a39a5c1-33b8-4dfb-9387-db8e3d51d120">
<img width="338" alt="스크린샷 2024-11-25 오후 9 49 19" src="https://github.com/user-attachments/assets/194cfe34-7252-44ae-8214-fba53c2c00f0">


## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
