### PR TITLE
[feat] 공통 Support component 공통으로 분리, main 페이지 적용

### DIFF
--- a/src/components/Supports/Supports.tsx
+++ b/src/components/Supports/Supports.tsx
@@ -1,22 +1,24 @@
 import Image from 'next/image';
-import { css, Theme } from '@emotion/react';
+import { css } from '@emotion/react';
 
-import { SupportThumbnail } from '~/components/Supports/SupportThumbnail';
 import { SUPPORTS } from '~/constant/supports';
+import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
 import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
-import { SectionTitleV2 } from '../SectionTitleV2';
+import { SupportThumbnail } from './SupportThumbnail';
 
-export function Supports() {
+export const Supports = () => {
+  const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
+
   return (
     <div css={[layoutCss]}>
-      <div css={titleContainerCss}>
-        <SectionTitleV2 css={titleContainerCss}>
-          <span css={titleCss}>후원사</span>
-        </SectionTitleV2>
-        <p css={subTitleCss}>디프만 후원사는 지속해서 추가 예정입니다.</p>
-      </div>
+      <h1 css={introCss.headline}>후원사</h1>
+      <p css={introCss.description}>
+        디프만은 IT비영리단체로 후원을 통해
+        {isMobileSize && <br />}더 많은 교육 기회에 도움을 받고 있습니다.
+      </p>
+
       <ul css={supportContainerCss}>
         {SUPPORTS.map(support => (
           <SupportThumbnail key={support.title} {...support} />
@@ -27,23 +29,42 @@ export function Supports() {
       </ul>
     </div>
   );
-}
+};
 
 const layoutCss = css`
-  padding: 120px 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 36px;
-  background-color: white;
-
-  ${mediaQuery('mobile')} {
-    padding: 0;
-    background-color: ${theme.colors.lightGray};
-  }
+  width: 100%;
+  background-color: ${theme.colors.black};
 `;
 
+const introCss = {
+  headline: css`
+    ${theme.typosV2.pretendard.bold32}
+    line-height: 150%;
+    color: ${theme.colors.white};
+
+    ${mediaQuery('mobile')} {
+      ${theme.typosV2.pretendard.bold28}
+      line-height: 150%;
+    }
+  `,
+  description: css`
+    ${theme.typosV2.pretendard.semibold20}
+    line-height: 150%;
+    margin-top: 42px;
+    text-align: center;
+    color: ${theme.colors.white};
+
+    ${mediaQuery('mobile')} {
+      ${theme.typosV2.pretendard.semibold18}
+    }
+  `,
+};
+
 const supportContainerCss = css`
+  margin-top: 88px;
   display: grid;
   width: 100%;
   max-width: 960px;
@@ -52,32 +73,11 @@ const supportContainerCss = css`
   column-gap: 12px;
   justify-items: center;
   justify-content: center;
+  padding: 0 20px;
 
-  ${mediaQuery('tablet')} {
+  ${mediaQuery('mobile')} {
     grid-template-columns: repeat(2, 1fr);
-    padding: 0 32px;
   }
-
-  @media (max-width: 600px) {
-    grid-template-columns: repeat(1, 1fr);
-    padding: 0 16px;
-  }
-`;
-
-const titleContainerCss = css`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-const titleCss = (theme: Theme) => css`
-  ${theme.typosV2.pretendard.semibold20}
-`;
-
-const subTitleCss = (theme: Theme) => css`
-  text-align: center;
-  ${theme.typosV2.pretendard.semibold16}
-  color: #555;
 `;
 
 const imageContainerCss = css`

--- a/src/features/About/sections/AboutSupportsSection.tsx
+++ b/src/features/About/sections/AboutSupportsSection.tsx
@@ -1,32 +1,14 @@
-import Image from 'next/image';
 import { css } from '@emotion/react';
 
-import { SupportThumbnail } from '~/components/Supports/SupportThumbnail';
-import { SUPPORTS } from '~/constant/supports';
-import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
+import { Supports } from '~/components/Supports';
 import { colors } from '~/styles/colors';
 import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
 export const AboutSupportsSection = () => {
-  const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
-
   return (
     <div css={[layoutCss]}>
-      <h1 css={introCss.headline}>후원사</h1>
-      <p css={introCss.description}>
-        디프만은 IT비영리단체로 후원을 통해
-        {isMobileSize && <br />}더 많은 교육 기회에 도움을 받고 있습니다.
-      </p>
-
-      <ul css={supportContainerCss}>
-        {SUPPORTS.map(support => (
-          <SupportThumbnail key={support.title} {...support} />
-        ))}
-        <div css={imageContainerCss}>
-          <Image src="/images/support/next.png" alt="what's next?" fill quality={100} />
-        </div>
-      </ul>
+      <Supports />
 
       <button css={supportButtonCss}>후원 문의하기</button>
     </div>
@@ -38,60 +20,8 @@ const layoutCss = css`
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
   background-color: ${theme.colors.black};
-`;
-
-const introCss = {
-  headline: css`
-    ${theme.typosV2.pretendard.bold32}
-    line-height: 150%;
-    color: ${theme.colors.white};
-
-    ${mediaQuery('mobile')} {
-      ${theme.typosV2.pretendard.bold28}
-      line-height: 150%;
-    }
-  `,
-  description: css`
-    ${theme.typosV2.pretendard.semibold20}
-    line-height: 150%;
-    margin-top: 42px;
-    text-align: center;
-    color: ${theme.colors.white};
-
-    ${mediaQuery('mobile')} {
-      ${theme.typosV2.pretendard.semibold18}
-    }
-  `,
-};
-
-const supportContainerCss = css`
-  margin-top: 88px;
-  display: grid;
-  width: 100%;
-  max-width: 960px;
-  grid-template-columns: repeat(3, 1fr);
-  row-gap: 20px;
-  column-gap: 12px;
-  justify-items: center;
-  justify-content: center;
-  padding: 0 20px;
-
-  ${mediaQuery('mobile')} {
-    grid-template-columns: repeat(2, 1fr);
-  }
-`;
-
-const imageContainerCss = css`
-  position: relative;
-  width: 100%;
-  height: 208px;
-
-  ${mediaQuery('mobile')} {
-    max-width: 450px;
-    padding: 18px;
-    height: 180px;
-  }
 `;
 
 const supportButtonCss = css`

--- a/src/features/Main/sections/MainSupportSection.tsx
+++ b/src/features/Main/sections/MainSupportSection.tsx
@@ -1,6 +1,24 @@
+import { css } from '@emotion/react';
+
+import { Supports } from '~/components/Supports';
+import { theme } from '~/styles/theme';
+
 /**
  * * Main 페이지 후원사 section
  */
 export const MainSupportSection = () => {
-  return <section>Support</section>;
+  return (
+    <section css={layoutCss}>
+      <Supports />
+    </section>
+  );
 };
+
+const layoutCss = css`
+  padding: 140px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  background-color: ${theme.colors.black};
+`;


### PR DESCRIPTION
## 작업 내용
- Supports 컴포넌트를 공통으로 분리합니다
- 메인 페이지에 적용합니다 (추후 스타일 수정이 필요합니다)

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
<img width="1413" alt="스크린샷 2024-11-25 오후 9 59 19" src="https://github.com/user-attachments/assets/915bda24-5a42-4752-a491-559378ca9dec">
<img width="336" alt="스크린샷 2024-11-25 오후 9 59 30" src="https://github.com/user-attachments/assets/20f48ee8-2964-49c6-9487-9d5c6a2240e5">

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
