### PR TITLE
버튼 호버 스타일 제거 및 폰트 굵기 수정

### DIFF
--- a/src/features/Blog/BlogSubscribeSection.tsx
+++ b/src/features/Blog/BlogSubscribeSection.tsx
@@ -81,8 +81,4 @@ const linkCss = (theme: Theme) => css`
   color: white;
   background-color: black;
   text-align: center;
-
-  &:hover {
-    color: ${theme.colors.pink};
-  }
 `;

--- a/src/styles/typo.ts
+++ b/src/styles/typo.ts
@@ -151,84 +151,84 @@ export const typosV2 = {
     bold62: css`
       font-size: ${pxToRem(62)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: ${pxToRem(74)};
       letter-spacing: -0.04em;
     `,
     bold44: css`
       font-size: ${pxToRem(44)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: ${pxToRem(53)};
       letter-spacing: -0.04em;
     `,
     bold32: css`
       font-size: ${pxToRem(32)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: ${pxToRem(38)};
       letter-spacing: -0.04em;
     `,
     bold28: css`
       font-size: ${pxToRem(28)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: ${pxToRem(33)};
       letter-spacing: -0.04em;
     `,
     bold24: css`
       font-size: ${pxToRem(24)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: normal;
       letter-spacing: ${pxToRem(-0.48)};
     `,
     bold20: css`
       font-size: ${pxToRem(20)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: ${pxToRem(24)};
       letter-spacing: -0.04em;
     `,
     bold18: css`
       font-size: ${pxToRem(18)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: normal;
       letter-spacing: ${pxToRem(-0.36)};
     `,
     bold16: css`
       font-size: ${pxToRem(16)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: ${pxToRem(19)};
       letter-spacing: -0.04em;
     `,
     bold10: css`
       font-size: ${pxToRem(10)};
       font-style: normal;
-      font-weight: 700;
+      font-weight: 600;
       line-height: ${pxToRem(15)};
       letter-spacing: ${pxToRem(-0.4)};
     `,
     semibold48: css`
       font-size: ${pxToRem(48)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(57)};
       letter-spacing: -0.04em;
     `,
     semibold32: css`
       font-size: ${pxToRem(32)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(48)};
       letter-spacing: -0.04em;
     `,
     semibold28: css`
       font-size: ${pxToRem(28)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(40)};
       letter-spacing: -0.04em;
     `,
@@ -236,125 +236,125 @@ export const typosV2 = {
       font-size: ${pxToRem(26)};
       font-style: normal;
       line-height: ${pxToRem(40)};
-      font-weight: 600;
+      font-weight: 500;
       letter-spacing: -0.04em;
     `,
     semibold24: css`
       font-size: ${pxToRem(24)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(36)};
       letter-spacing: -0.04em;
     `,
     semibold20: css`
       font-size: ${pxToRem(20)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(30)};
       letter-spacing: -0.04em;
     `,
     semibold18: css`
       font-size: ${pxToRem(18)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(32)};
       letter-spacing: -0.04em;
     `,
     semibold16: css`
       font-size: ${pxToRem(16)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(24)};
       letter-spacing: -0.04em;
     `,
     semibold15: css`
       font-size: ${pxToRem(15)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(22.5)};
       letter-spacing: ${pxToRem(-0.75)};
     `,
     semibold14: css`
       font-size: ${pxToRem(14)};
       font-style: normal;
-      font-weight: 600;
+      font-weight: 500;
       line-height: ${pxToRem(21)};
       letter-spacing: -0.04em;
     `,
     medium18: css`
       font-size: ${pxToRem(18)};
       font-style: normal;
-      font-weight: 500;
+      font-weight: 400;
       line-height: ${pxToRem(27)};
       letter-spacing: ${pxToRem(-0.54)};
     `,
     medium16: css`
       font-size: ${pxToRem(16)};
       font-style: normal;
-      font-weight: 500;
+      font-weight: 400;
       line-height: ${pxToRem(24)};
       letter-spacing: -0.05em;
     `,
     medium15: css`
       font-size: ${pxToRem(15)};
       font-style: normal;
-      font-weight: 500;
+      font-weight: 400;
       line-height: ${pxToRem(22.5)};
       letter-spacing: ${pxToRem(-0.6)};
     `,
     medium14: css`
       font-size: ${pxToRem(14)};
       font-style: normal;
-      font-weight: 500;
+      font-weight: 400;
       line-height: ${pxToRem(17)};
       letter-spacing: -0.05em;
     `,
     medium13: css`
       font-size: ${pxToRem(13)};
       font-style: normal;
-      font-weight: 500;
+      font-weight: 400;
       line-height: ${pxToRem(15)};
       letter-spacing: -0.01em;
     `,
     regular20: css`
       font-size: ${pxToRem(20)};
       font-style: normal;
-      font-weight: 400;
+      font-weight: 300;
       line-height: ${pxToRem(30)};
       letter-spacing: -0.05em;
     `,
     regular18: css`
       font-size: ${pxToRem(18)};
       font-style: normal;
-      font-weight: 400;
+      font-weight: 300;
       line-height: ${pxToRem(27)};
       letter-spacing: -0.05em;
     `,
     regular16: css`
       font-size: ${pxToRem(16)};
       font-style: normal;
-      font-weight: 400;
+      font-weight: 300;
       line-height: ${pxToRem(24)};
       letter-spacing: ${pxToRem(-0.64)};
     `,
     regular14: css`
       font-size: ${pxToRem(14)};
       font-style: normal;
-      font-weight: 400;
+      font-weight: 300;
       line-height: ${pxToRem(21)};
       letter-spacing: -0.05em;
     `,
     regular9: css`
       font-size: ${pxToRem(9)};
       font-style: normal;
-      font-weight: 400;
+      font-weight: 300;
       line-height: ${pxToRem(15)};
       letter-spacing: -0.02em;
     `,
     regular8: css`
       font-size: ${pxToRem(8)};
       font-style: normal;
-      font-weight: 400;
+      font-weight: 300;
       line-height: ${pxToRem(12)};
       letter-spacing: -0.02em;
     `,


### PR DESCRIPTION
## 작업 내용

디자인 팀에서 요청해주셨던 버튼 호버 스타일을 제거했어요.
그리고 피그마와 웹 상의 폰트 싱크가 맞지 않는 부분이 있어서 이를 맞추기 위해 폰트 굵기를 `-100`씩 변경을 했어요

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
