### PR TITLE
블로그 카드 스타일 수정 및 페이지 타이틀 동적 스타일 적용

### DIFF
--- a/src/components/Blog/BlogPostThumbnail.tsx
+++ b/src/components/Blog/BlogPostThumbnail.tsx
@@ -68,7 +68,7 @@ const articleCss = css`
   ${mediaQuery('tablet')} {
   }
   ${mediaQuery('mobile')} {
-    height: 180px;
+    height: 220px;
     max-width: 460px;
   }
   &:hover {

--- a/src/components/Supports/Supports.tsx
+++ b/src/components/Supports/Supports.tsx
@@ -15,8 +15,8 @@ export const Supports = () => {
 
   return (
     <div css={[layoutCss]}>
-      <h1 css={introCss.headline}>후원사</h1>
-      <p css={introCss.description}>
+      <h1 css={introCss.headline(isAboutPage)}>후원사</h1>
+      <p css={introCss.description(isAboutPage)}>
         디프만은 IT 비영리단체로 후원을 통해 {isMobileSize && <br />}더 많은 교육 기회에 도움을 받고
         있습니다.
       </p>
@@ -52,7 +52,7 @@ const introCss = {
   description: (isAboutPage = false) => css`
     ${isAboutPage ? theme.typosV2.pretendard.semibold18 : theme.typosV2.pretendard.semibold20}
     line-height: 150%;
-    margin-top: 42px;
+    margin-top: ${isAboutPage ? '25' : '42'}px;
     text-align: center;
     color: ${theme.colors.white};
 

--- a/src/components/Supports/Supports.tsx
+++ b/src/components/Supports/Supports.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
 import { SUPPORTS } from '~/constant/supports';
@@ -9,11 +10,13 @@ import { SupportThumbnail } from './SupportThumbnail';
 
 export const Supports = () => {
   const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
+  const { pathname } = useRouter();
+  const isAboutPage = pathname === '/about';
 
   return (
     <div css={[layoutCss]}>
-      <h1 css={introCss.headline}>후원사</h1>
-      <p css={introCss.description}>
+      <h1 css={introCss.headline(isAboutPage)}>후원사</h1>
+      <p css={introCss.description(isAboutPage)}>
         디프만은 IT비영리단체로 후원을 통해 {isMobileSize && <br />}더 많은 교육 기회에 도움을 받고
         있습니다.
       </p>
@@ -36,9 +39,9 @@ const layoutCss = css`
 `;
 
 const introCss = {
-  headline: css`
-    ${theme.typosV2.pretendard.bold44}
+  headline: (isAboutPage = false) => css`
     line-height: 150%;
+    ${isAboutPage ? theme.typosV2.pretendard.bold32 : theme.typosV2.pretendard.bold44}
     color: ${theme.colors.white};
 
     ${mediaQuery('mobile')} {
@@ -46,8 +49,8 @@ const introCss = {
       line-height: 150%;
     }
   `,
-  description: css`
-    ${theme.typosV2.pretendard.semibold20}
+  description: (isAboutPage = false) => css`
+    ${isAboutPage ? theme.typosV2.pretendard.semibold18 : theme.typosV2.pretendard.semibold20}
     line-height: 150%;
     margin-top: 42px;
     text-align: center;

--- a/src/features/Blog/BlogContentSection.tsx
+++ b/src/features/Blog/BlogContentSection.tsx
@@ -74,5 +74,6 @@ const blogContainerCss = css`
   }
   ${mediaQuery('mobile')} {
     grid-template-columns: repeat(1, 1fr);
+    gap: 20px;
   }
 `;


### PR DESCRIPTION
## 작업 내용

블로그 카드 스타일을 모바일에만 적용될 수 있도록 스타일을 적용했어요. `About` 페이지에서 사용하는 컴포넌트 중 하나가 메인 화면에서는 (예) `44` 정도의 폰트 사이즈를 가져야하고, `About` 페이지에서는 `22` 정도의 사이즈를 가져야해서 `useRouter`을 사용하여 판별 코드를 통해 분기 처리를 적용했어요

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
