### PR TITLE
지원 관련 테스트 환경 구성

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -46,14 +46,14 @@ const buttonCss = (theme: Theme, size: ButtonSize) => css`
     }
   `}
 
-
+/* NOTE: 16기에서는 불필요해서 사용을 하지 않았으나, 추후 사용을 위해 주석을 해제해주세요
   &:hover {
     background-color: ${theme.colors.blue};
   }
 
   &:active {
     background-color: ${theme.colors.blue};
-  }
+  } */
 
   &:disabled {
     background-color: ${theme.colors.lightGray};

--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -9,35 +9,25 @@ import { MobileMenu } from '~/components/GNB/MobileMenu';
 import { MobileMenuIcon } from '~/components/GNB/MobileMenuIcon';
 import { GNB_MENU_NAME, GNBMenu } from '~/constant/gnb';
 import { useDropDown } from '~/hooks/useDropdown';
+import useIsInProgress from '~/hooks/useIsInProgress';
 import { mediaQuery } from '~/styles/media';
 
 const LOGO_IMAGE = `/images/16th/logo/depromeet.svg`;
-const CURRENT_GENERATION = 16;
 
-function NotifyButton() {
-  const handleClick = () => window.open('https://bit.ly/3YJgDmR');
+function ApplyButton() {
+  const { isInProgress, dDay } = useIsInProgress();
+  const router = useRouter();
+
+  const onClick = () => {
+    router.push('/recruit');
+  };
+
   return (
-    <Button onClick={handleClick} css={linkButtonCss}>
-      {CURRENT_GENERATION}기 모집 알림 신청
+    <Button disabled={!isInProgress} css={linkButtonCss} onClick={onClick} suppressHydrationWarning>
+      {isInProgress ? '16기 지원하기' : dDay < 0 ? `D${dDay}` : `지원 마감`}
     </Button>
   );
 }
-
-// TODO: 웹 사이트 오픈 시에 주석 해제
-// function ApplyButton() {
-//   const { isInProgress, dDay } = useIsInProgress();
-//   const router = useRouter();
-//
-//   const onClick = () => {
-//     router.push('/apply');
-//   };
-//
-//   return (
-//     <Button disabled={!isInProgress} css={linkButtonCss} onClick={onClick} suppressHydrationWarning>
-//       {isInProgress ? '16기 지원하기' : dDay < 0 ? `D${dDay}` : `지원 마감`}
-//     </Button>
-//   );
-// }
 
 const linkButtonCss = css`
   height: 37px;
@@ -73,7 +63,7 @@ export function GNB() {
               </li>
             ))}
           </ul>
-          <NotifyButton />
+          <ApplyButton />
         </div>
       </nav>
       <nav css={mobileNavCss} ref={containerRef}>

--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -19,7 +19,7 @@ function ApplyButton() {
   const router = useRouter();
 
   const onClick = () => {
-    router.push('/recruit');
+    router.push('/recruit#apply');
   };
 
   return (

--- a/src/components/Main/RecruitTextSection.tsx
+++ b/src/components/Main/RecruitTextSection.tsx
@@ -11,7 +11,7 @@ export function RecruitTextSection() {
   const router = useRouter();
 
   const onButtonClick = () => {
-    router.push('/recruit');
+    router.push('/recruit#apply');
   };
 
   return (

--- a/src/components/Main/RecruitTextSection.tsx
+++ b/src/components/Main/RecruitTextSection.tsx
@@ -11,7 +11,7 @@ export function RecruitTextSection() {
   const router = useRouter();
 
   const onButtonClick = () => {
-    router.push('/apply');
+    router.push('/recruit');
   };
 
   return (

--- a/src/components/Positions/PositionsItem.tsx
+++ b/src/components/Positions/PositionsItem.tsx
@@ -29,8 +29,7 @@ export function PositionsItem({ type, title, link, description, keyword }: Posit
   };
 
   const renderContent = ({ state = 'default' }: { state?: 'hover' | 'default' }) => {
-    // FIXME: 링크 방어 코드 추후 변경
-    // if (!link) return null;
+    if (!link) return null;
     if (progressState === 'IN_PROGRESS') {
       return (
         <Fragment>

--- a/src/constant/common.ts
+++ b/src/constant/common.ts
@@ -12,7 +12,7 @@ export const NOTION_RECRUIT_PATH =
 
 // NOTE: UTC 타임존에 맞추기 위해 9시간을 뺌
 export const START_DATE = adjustToUTC({ dateString: '2024-12-01T19:00:00.000Z' });
-export const END_DATE = adjustToUTC({ dateString: '2024-12-02T15:00:00.000Z' });
+export const END_DATE = adjustToUTC({ dateString: '2024-12-02T19:00:00.000Z' });
 
 // export const START_DATE = '2024-04-19T06:00:00.000Z'; // test
 // export const END_DATE = '2025-03-04T20:00:00.000Z'; // test

--- a/src/constant/common.ts
+++ b/src/constant/common.ts
@@ -1,3 +1,5 @@
+import { adjustToUTC } from '~/utils/utils';
+
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 export const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
@@ -9,9 +11,8 @@ export const NOTION_RECRUIT_PATH =
   'https://depromeet.notion.site/DEPROMEET-13th-f1e931cf073e43c4aeca44a4521b44be';
 
 // NOTE: UTC 타임존에 맞추기 위해 9시간을 뺌
-// TODO: 개발용으로 임시로 데이트 타임을 변경
-export const START_DATE = '2024-12-03T14:59:59.000Z'; // 04.27 00:00
-export const END_DATE = '2024-12-09T14:59:59.000Z'; // 05.04 11:59:59
+export const START_DATE = adjustToUTC({ dateString: '2024-12-01T19:00:00.000Z' });
+export const END_DATE = adjustToUTC({ dateString: '2024-12-02T15:00:00.000Z' });
 
 // export const START_DATE = '2024-04-19T06:00:00.000Z'; // test
 // export const END_DATE = '2025-03-04T20:00:00.000Z'; // test

--- a/src/constant/gnb.ts
+++ b/src/constant/gnb.ts
@@ -5,7 +5,7 @@
 
 export type GNBMenu = {
   name: '소개' | '모집 안내' | '프로젝트' | '블로그' | '지원하기' | '지원하기';
-  href: '/about' | '/recruit' | '/project' | '/blog';
+  href: '/about' | '/recruit' | '/project' | '/blog' | 'recruit#apply';
   type: 'text' | 'button';
   isNewTab?: boolean;
 };
@@ -57,7 +57,7 @@ export const GNB_MOBILE_MENU_NAME: GNBMenu[] = [
   },
   {
     name: '지원하기',
-    href: '/recruit',
+    href: '/recruit#apply',
     type: 'button',
   },
 ];

--- a/src/constant/gnb.ts
+++ b/src/constant/gnb.ts
@@ -5,7 +5,7 @@
 
 export type GNBMenu = {
   name: '소개' | '모집 안내' | '프로젝트' | '블로그' | '지원하기' | '지원하기';
-  href: '/about' | '/recruit' | '/project' | '/blog' | 'recruit#apply';
+  href: '/about' | '/recruit' | '/recruit#apply' | '/project' | '/blog';
   type: 'text' | 'button';
   isNewTab?: boolean;
 };

--- a/src/constant/gnb.ts
+++ b/src/constant/gnb.ts
@@ -1,6 +1,11 @@
+/** NOTE
+ * 본래는 `href` 속셍어 /apply 속성도 있었지만, 16기에서는 불필요하여 삭제했어요.
+ * 개발을 진행하시면서 참고를 해주세요
+ */
+
 export type GNBMenu = {
-  name: '소개' | '모집 안내' | '프로젝트' | '블로그' | '지원하기' | '16기 모집 알림 신청';
-  href: '/about' | '/recruit' | '/project' | '/blog' | '/apply' | 'https://bit.ly/3YJgDmR';
+  name: '소개' | '모집 안내' | '프로젝트' | '블로그' | '지원하기' | '지원하기';
+  href: '/about' | '/recruit' | '/project' | '/blog';
   type: 'text' | 'button';
   isNewTab?: boolean;
 };
@@ -51,9 +56,8 @@ export const GNB_MOBILE_MENU_NAME: GNBMenu[] = [
     type: 'text',
   },
   {
-    name: '16기 모집 알림 신청',
-    href: 'https://bit.ly/3YJgDmR',
-    type: 'text',
-    isNewTab: true,
+    name: '지원하기',
+    href: '/recruit',
+    type: 'button',
   },
 ];

--- a/src/features/Main/sections/MainIntroSection.tsx
+++ b/src/features/Main/sections/MainIntroSection.tsx
@@ -1,28 +1,29 @@
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
 import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
+import useIsInProgress from '~/hooks/useIsInProgress';
 import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
+import { getPathToRecruit } from '~/utils/utils';
 
 /**
  * * Main 페이지 Intro + 지원 버튼 section
  */
 export const MainIntroSection = () => {
   const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
-  // FIXME: 추후 링크 상수화 진행
-  const handleClick = () => window.open('https://bit.ly/3YJgDmR');
   const [isClientReady, setIsClientReady] = useState<boolean>(false);
+  const router = useRouter();
+  const { progressState } = useIsInProgress();
+  const { label, action } = getPathToRecruit(router, progressState);
 
   useEffect(() => {
     setIsClientReady(true);
   }, []);
 
   return (
-    /** FIXME: 디자이너분들께 공유드리기, 사진 깨짐 현상 존재
-     * 추가로 보완해야할 부분 추가
-     * */
     <section css={containerCss}>
       {isClientReady && (
         <article css={articleCss}>
@@ -41,8 +42,8 @@ export const MainIntroSection = () => {
             id={'title'}
             alt={'디프만 메인'}
           />
-          <button css={buttonCss} onClick={handleClick}>
-            16기 모집 알림 신청
+          <button css={buttonCss} onClick={action}>
+            {label}
           </button>
         </article>
       )}

--- a/src/features/Main/sections/MainRecruitSection.tsx
+++ b/src/features/Main/sections/MainRecruitSection.tsx
@@ -1,17 +1,22 @@
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
 import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
+import useIsInProgress from '~/hooks/useIsInProgress';
 import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
+import { getPathToRecruit } from '~/utils/utils';
 
 /**
  * * Main 페이지 지원하기 section
  * TODO: 링크 이벤트 연결하기
  */
 export const MainRecruitSection = () => {
+  const router = useRouter();
   const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
-  const handleClick = () => window.open('https://bit.ly/3YJgDmR');
+  const { progressState } = useIsInProgress();
+  const { action, label } = getPathToRecruit(router, progressState);
 
   return (
     <section css={containerCss}>
@@ -20,8 +25,8 @@ export const MainRecruitSection = () => {
         <h1 css={text.titleCss}>
           디프만과 함께 성장 할 <br /> 16기 디퍼를 모집합니다
         </h1>
-        <button css={buttonCss} onClick={handleClick}>
-          16기 모집 알림 신청
+        <button css={buttonCss} onClick={action}>
+          {label}
         </button>
         <Image
           width={!isMobileSize ? 1051 : 440}

--- a/src/features/Recruit/sections/RecuritPosition.tsx
+++ b/src/features/Recruit/sections/RecuritPosition.tsx
@@ -7,7 +7,7 @@ import { mediaQuery } from '~/styles/media';
 
 export const RecuritPosition = () => {
   return (
-    <section css={layoutCss}>
+    <section css={layoutCss} id="apply">
       <div css={containerCss}>
         <div css={headerCss}>
           <div css={titleCss}>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,8 @@
+import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 import Cookies from 'js-cookie';
+
+import { RecruitState } from '~/hooks/useIsInProgress';
 
 /**
  * @description
@@ -67,4 +70,57 @@ function setPopupCookie({ cookieName, expires = 1 }: { cookieName: string; expir
   Cookies.set(cookieName, 'true', { expires: expires });
 }
 
-export { generateModalPositionStyle, getPopupCookie, setPopupCookie };
+/**
+ * @description
+ * UTC 타임존을 편하게 맞춰주는 유틸함수예요, 주로 지원 및 마감 시간에 사용되고 있어요.
+ * 기본 값으로 한국 시간을 기준으로 9시간이 설정되어있어요
+ *
+ * @params {string} dateString
+ * @params {number} offsetHours
+ */
+
+function adjustToUTC({
+  dateString,
+  offsetHours = 9,
+}: {
+  dateString: string;
+  offsetHours?: number;
+}) {
+  const date = new Date(dateString);
+  date.setHours(date.getHours() - offsetHours);
+  return date.toISOString();
+}
+
+/**
+ * @description
+ * 현재 지원 시각에 맞춰 지원 상태를 변경해주는 유틸함수예요
+ *
+ * @param {import('next/router').NextRouter} router - Next.js의 `useRouter`를 통해 얻은 라우터 객체
+ * @param {RecruitState} progressState - 현재 모집 상태. `IN_PROGRESS`, `FINISH`, 또는 기타 상태
+ *
+ * @returns {{ action: (() => void), label: string }}
+ */
+
+function getPathToRecruit(router: ReturnType<typeof useRouter>, progressState: RecruitState) {
+  if (progressState === 'IN_PROGRESS') {
+    return {
+      action: () => router.push('/recruit'),
+      label: '지원하기',
+    };
+  } else if (progressState === 'FINISH') {
+    return {
+      action: () => window.open('https://bit.ly/3YJgDmR'),
+      label: '16기 모집 알림 신청',
+    };
+  }
+
+  return { action: () => {}, label: '지원 마감' };
+}
+
+export {
+  adjustToUTC,
+  generateModalPositionStyle,
+  getPathToRecruit,
+  getPopupCookie,
+  setPopupCookie,
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -104,7 +104,7 @@ function adjustToUTC({
 function getPathToRecruit(router: ReturnType<typeof useRouter>, progressState: RecruitState) {
   if (progressState === 'IN_PROGRESS') {
     return {
-      action: () => router.push('/recruit'),
+      action: () => router.push('/recruit#apply'),
       label: '지원하기',
     };
   } else if (progressState === 'FINISH') {


### PR DESCRIPTION
## 목적
- 운영진들에게 공유할 지원 관련 테스트 환경 구성을 진행했어요

## 작업 내용
- 커밋 내용을 참조해주세요
  - 모집 알림 신청 버튼에서 모집 안내 페이지의 지원 섹션으로 가도록 변경 처리를 했어요
  - 관련 부가 유틸 함수들을 만들었어요
    - 지원 시간 관련 UTC 계산을 손쉽게 해주는 유틸 함수
    - 지원하기 관련 텍스트 및 링크를 자동으로 설정해주는 유틸 함수
  - 기타 지원에 관련된 레이아웃 작업들을 진행했어요 

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
