### PR TITLE
feat: 18기 모집 안내 페이지 구현

### DIFF
--- a/src/components/MemberRecruitment/MemberRecruitment.tsx
+++ b/src/components/MemberRecruitment/MemberRecruitment.tsx
@@ -1,103 +1,134 @@
 import { css, Theme } from '@emotion/react';
 
 import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
-import { sectionBg } from '~/styles/background';
 import { colors } from '~/styles/colors';
-import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
 interface RecruitmentStep {
   title: string;
   date: string;
+  subtext?: string;
+  showArrow?: boolean;
 }
 
 const recruitmentSteps: RecruitmentStep[] = [
-  { title: '서류 접수 시작', date: '06.30' },
-  { title: '서류 마감', date: '07.06' },
-  { title: '서류 발표', date: '07.13' },
-  { title: '온라인 인터뷰', date: '07.19-20' },
-  { title: '최종 합격', date: '07.26' },
+  {
+    title: '서류 접수',
+    date: '02.12 (목) -\n02.18 (수)',
+    subtext: '02.18 수요일\n23:59:59까지 제출',
+    showArrow: true,
+  },
+  {
+    title: '서류 발표',
+    date: '02.23 (월)',
+    showArrow: true,
+  },
+  {
+    title: '온라인 인터뷰',
+    date: '02.28 (토) -\n03.02 (월)',
+    showArrow: true,
+  },
+  {
+    title: '최종 발표',
+    date: '03.05 (목)',
+  },
 ];
 
 export const MemberRecruitment = () => {
   const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
-  const { isTargetSize: isTabletSize } = useCheckWindowSize('tablet');
+  const { isTargetSize: _isTabletSize } = useCheckWindowSize('tablet');
 
   return (
-    <>
-      {!isTabletSize && !isMobileSize && (
-        <div css={containerCss}>
-          <div css={contentStyles}>
-            <div css={headerCss}>
-              <h2 css={titleCss}>멤버 모집</h2>
-            </div>
+    <div css={containerCss}>
+      <div css={contentStyles}>
+        <div css={headerCss}>
+          <h2 css={titleCss}>
+            <span className="desktop-text">18기 모집 일정</span>
+            <span className="mobile-text">모집 일정</span>
+          </h2>
+        </div>
 
-            {/* 모집 단계 */}
-            <div css={stepsContainerCss}>
-              {recruitmentSteps.map((step, index) => (
-                <div key={index} css={stepBoxCss}>
-                  <h3 css={stepTitleCss}>{step.title}</h3>
-                  <p css={stepDateCss}>{step.date}</p>
-                </div>
-              ))}
-            </div>
+        <div css={infoContainerCss}>
+          {/* 모집 타임라인 */}
+          <div css={timelineContainerCss}>
+            {recruitmentSteps.map((step, index) => (
+              <div key={index} css={timelineItemCss}>
+                <h3 css={stepTitleCss}>{step.title}</h3>
+                <p css={stepDateCss}>{step.date}</p>
+                {step.subtext && <p css={stepSubtextCss}>{step.subtext}</p>}
+              </div>
+            ))}
 
-            {/* 지원 방법 */}
-            <div css={applicationSectionCss}>
-              <h3 css={applicationTitleCss}>지원 방법</h3>
+            {/* 화살표들 - absolute positioning */}
+            {!isMobileSize && (
+              <>
+                {recruitmentSteps.slice(0, -1).map((step, index) =>
+                  step.showArrow ? (
+                    <div key={`arrow-${index}`} css={arrowContainerCss(index)}>
+                      <svg
+                        width="40"
+                        height="40"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M9 18l6-6-6-6"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </div>
+                  ) : null
+                )}
+              </>
+            )}
+          </div>
 
+          {/* 모바일 화살표 */}
+          {isMobileSize && (
+            <>
+              <div css={mobileArrowContainerCss}>
+                <svg
+                  width="40"
+                  height="40"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M18 9l-6 6-6-6"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+            </>
+          )}
+
+          {/* 전형 절차 */}
+          <div css={applicationSectionCss}>
+            <h3 css={applicationTitleCss}>전형 절차</h3>
+
+            <div css={applicationContainer}>
               <div css={applicationStepCss}>
-                <h4 css={stepNumberCss}>1차 서류</h4>
+                <h4 css={stepNumberCss}>1차. 서류</h4>
                 <p css={stepDescriptionCss}>자기소개서 작성 및 이력서/포트폴리오 제출</p>
               </div>
 
               <div css={applicationStepCss}>
-                <h4 css={stepNumberCss}>2차 인터뷰</h4>
+                <h4 css={stepNumberCss}>2차. 인터뷰</h4>
                 <p css={stepDescriptionCss}>직무 역량 및 컬처핏 인터뷰</p>
               </div>
-
-              <div css={rulerCss} />
             </div>
           </div>
         </div>
-      )}
-      {(isTabletSize || isMobileSize) && (
-        <div css={containerCss}>
-          <div css={contentStyles}>
-            <div css={headerCss}>
-              <h2 css={titleCss}>멤버 모집</h2>
-            </div>
-
-            {/* 모집 단계 */}
-            <div css={stepsContainerCss}>
-              {recruitmentSteps.map((step, index) => (
-                <div key={index} css={stepBoxCss}>
-                  <h3 css={stepTitleCss}>{step.title}</h3>
-                  <p css={stepDateCss}>{step.date}</p>
-                </div>
-              ))}
-            </div>
-
-            {/* 지원 방법 */}
-            <div css={applicationSectionCss}>
-              <h3 css={applicationTitleCss}>지원 방법</h3>
-
-              <div css={applicationStepCss}>
-                <h4 css={stepNumberCss}>1차 서류</h4>
-                <p css={stepDescriptionCss}>자기소개서 작성 및 이력서/포트폴리오 제출</p>
-              </div>
-
-              <div css={applicationStepCss}>
-                <h4 css={stepNumberCss}>2차 인터뷰</h4>
-                <p css={stepDescriptionCss}>직무 역량 및 컬처핏 인터뷰</p>
-              </div>
-
-              <div css={rulerCss} />
-            </div>
-          </div>
-        </div>
-      )}
-    </>
+      </div>
+    </div>
   );
 };
 
@@ -108,45 +139,16 @@ const containerCss = (_theme: Theme) => css`
   align-items: center;
   width: 100%;
   margin: 0 auto;
-  padding: 120px 20px 80px 20px;
-  background-color: ${colors.primary.gray};
-  ${sectionBg};
+  padding: 160px 0;
+  background-color: #f9fbff;
   overflow: hidden;
 
-  ${mediaQuery('tablet')} {
-    padding: 30px 20px 140px 20px;
+  @media (min-width: 768px) and (max-width: 1279px) {
+    padding: 80px 0;
   }
 
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: -20px;
-    right: -50px;
-    width: 304.5px;
-    height: 304.5px;
-    background-image: url('/images/17th/shapes/blue_arrow.png');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: bottom right;
-    z-index: 2;
-    opacity: 1;
-    transform: rotate(350deg);
-
-    ${mediaQuery('tablet')} {
-      bottom: -40px;
-      right: -40px;
-      width: 260px;
-      height: 260px;
-      transform: rotate(0deg);
-    }
-  }
-
-  ${mediaQuery('mobile')} {
-    padding: 60px 16px;
-
-    &::after {
-      display: none;
-    }
+  @media (max-width: 767px) {
+    padding: 40px 0;
   }
 `;
 
@@ -156,165 +158,323 @@ const contentStyles = css`
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 900px;
+  max-width: 1280px;
 `;
 
 const headerCss = css`
   text-align: center;
-  margin-bottom: 60px;
+  margin-bottom: 80px;
 
-  ${mediaQuery('mobile')} {
-    margin-bottom: 40px;
+  @media (min-width: 768px) and (max-width: 1279px) {
+    margin-bottom: 60px;
+  }
+
+  @media (max-width: 767px) {
+    margin-bottom: 24px;
   }
 `;
 
 const titleCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.head1};
-  color: ${theme.colors.primary.darknavy};
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+  color: ${theme.colors.grey18[900]};
+  margin: 0;
 
-  ${mediaQuery('mobile')} {
-    font-size: 28px;
+  .mobile-text {
+    display: none;
   }
-`;
+  .desktop-text {
+    display: inline;
+  }
 
-const stepsContainerCss = css`
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 16px;
-  margin-bottom: 16px;
+  @media (max-width: 767px) {
+    font-size: 26px;
+    line-height: 1.25;
+    letter-spacing: -0.05em;
 
-  ${mediaQuery('mobile')} {
-    grid-template-columns: repeat(6, 1fr);
-    gap: 12px;
-
-    & > div:nth-of-type(1) {
-      grid-column: 1 / 3;
+    .desktop-text {
+      display: none;
     }
-
-    & > div:nth-of-type(2) {
-      grid-column: 3 / 5;
-    }
-
-    & > div:nth-of-type(3) {
-      grid-column: 5 / 7;
-    }
-
-    & > div:nth-of-type(4) {
-      grid-column: 1 / 4;
-    }
-
-    & > div:nth-of-type(5) {
-      grid-column: 4 / 7;
+    .mobile-text {
+      display: inline;
     }
   }
 `;
 
-const stepBoxCss = css`
-  background-color: ${colors.primary.gray};
-  border: 1px solid ${colors.primary.blue};
-  padding: 28px 26px;
-  text-align: center;
-  min-height: 120px;
+const infoContainerCss = css`
+  max-width: 1200px;
+  padding: 0 40px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  gap: 8px;
+  gap: 12px;
 
-  ${mediaQuery('tablet')} {
-    padding: 28px 0;
-    min-height: 100px;
+  @media (min-width: 768px) and (max-width: 1279px) {
+    padding: 0 40px;
+    gap: 8px;
   }
-  ${mediaQuery('mobile')} {
-    padding: 20px 12px;
-    min-height: 100px;
+
+  @media (max-width: 767px) {
+    padding: 0 20px;
+    gap: 8px;
+  }
+`;
+
+const timelineContainerCss = css`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    gap: 8px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+`;
+
+const timelineItemCss = css`
+  background-color: ${colors.white};
+  border: 1px solid ${colors.grey18[200]};
+  border-radius: 12px;
+  padding: 32px;
+  text-align: left;
+  height: 320px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 12px;
+  box-shadow: 0px 8px 32px 0px rgba(47, 51, 55, 0.06);
+  flex: 1;
+
+  @media (min-width: 1280px) {
+    &:first-of-type {
+      flex: 0 0 290px;
+    }
+  }
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    height: 240px;
+    padding: 20px 16px;
+    gap: 8px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    height: 200px;
+    padding: 20px 16px;
+    gap: 8px;
+    width: 100%;
+    flex: none;
   }
 `;
 
 const stepTitleCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.sub1Semibold};
-  color: ${theme.colors.primary.darknavy};
+  font-family: 'Pretendard', sans-serif;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: -0.64px;
+  color: ${theme.colors.grey18[900]};
+  margin: 0;
 
-  ${mediaQuery('mobile')} {
-    font-size: 14px;
+  /* 768px ~ 1279px */
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 22px;
+    letter-spacing: -0.22px;
+  }
+
+  /* 360px ~ 767px */
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 20px;
+    letter-spacing: -0.2px;
   }
 `;
 
 const stepDateCss = css`
-  ${theme.typosV3.pretendard.sub2Semibold};
+  font-family: 'Pretendard', sans-serif;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -1.3px;
   color: ${colors.primary.blue};
-  font-weight: 400;
+  margin: 0;
+  white-space: pre-line;
 
-  ${mediaQuery('mobile')} {
-    font-size: 16px;
+  /* 768px ~ 1279px */
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 20px;
+    letter-spacing: -0.2px;
+    line-height: 1.4;
+  }
+
+  /* 360px ~ 767px */
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 18px;
+    line-height: 1.4;
+    letter-spacing: 0;
   }
 `;
 
+const stepSubtextCss = css`
+  font-family: 'Pretendard', sans-serif;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: ${theme.colors.grey18[900]};
+  margin: 0;
+  white-space: pre-line;
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 16px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 14px;
+  }
+`;
+
+const arrowContainerCss = (index: number) => css`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  background-color: ${colors.white};
+  border: 1px solid ${colors.grey18[200]};
+  border-radius: 50%;
+  color: ${colors.primary.blue};
+  box-shadow: 0px 8px 32px 0px rgba(47, 51, 55, 0.06);
+  width: 56px;
+  height: 56px;
+  z-index: 10;
+
+  @media (min-width: 1280px) {
+    ${index === 0 && `left: calc(290px + 12px / 2 - 56px / 2);`}
+    ${index === 1 && `left: calc(290px + 12px + 33.33% + 12px / 2 - 56px / 2);`}
+    ${index === 2 && `left: calc(290px + 12px + 66.66% + 12px / 2 - 56px / 2);`}
+  }
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    width: 48px;
+    height: 48px;
+    ${index === 0 && `left: calc(25% - 48px / 2 - 8px / 2);`}
+    ${index === 1 && `left: calc(50% - 48px / 2);`}
+    ${index === 2 && `left: calc(75% + 48px / 2 + 8px / 2);`}
+  }
+`;
+
+const mobileArrowContainerCss = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 14px 14px 16px;
+  background-color: ${colors.white};
+  border: 1px solid ${colors.grey18[200]};
+  border-radius: 34px;
+  color: ${colors.primary.blue};
+  margin: 0 auto;
+  box-shadow: 0px 8px 32px 0px rgba(47, 51, 55, 0.06);
+`;
+
 const applicationSectionCss = css`
-  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  background-color: ${colors.primary.gray};
-  border: 1px solid ${colors.primary.blue};
-  padding: 40px;
-  text-align: center;
-  height: 265px;
+  justify-content: flex-start;
+  align-items: flex-start;
+  background-color: ${colors.white};
+  border: 1px solid ${colors.grey18[200]};
+  border-radius: 12px;
+  padding: 32px;
+  text-align: left;
+  gap: 48px;
+  width: 100%;
+  height: 340px;
+  box-shadow: 0px 8px 32px 0px rgba(47, 51, 55, 0.06);
 
-  ${mediaQuery('mobile')} {
-    padding: 30px 20px;
+  @media (min-width: 768px) and (max-width: 1279px) {
+    height: 340px;
+    padding: 28px;
+    gap: 48px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    height: 240px;
+    padding: 24px;
+    gap: 0;
+    justify-content: space-between;
   }
 `;
 
 const applicationTitleCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.head6};
-  color: ${theme.colors.primary.darknavy};
-  margin: 0 0 20px 0;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 32px;
+  font-weight: 700;
+  color: ${theme.colors.grey18[900]};
+  line-height: 1.4;
+  letter-spacing: -0.64px;
+  margin: 0;
 
-  ${mediaQuery('mobile')} {
+  @media (min-width: 360px) and (max-width: 767px) {
     font-size: 20px;
-    margin-bottom: 30px;
+    letter-spacing: -0.2px;
   }
+`;
+
+const applicationContainer = css`
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  width: 100%;
 `;
 
 const applicationStepCss = css`
-  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 
-  &:last-child {
-    margin-bottom: 0;
+  @media (min-width: 360px) and (max-width: 767px) {
+    gap: 4px;
   }
 `;
 
-const rulerCss = css`
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 20px;
-  background-image: url('/images/project/17기/footer-ruler.png');
-  background-size: cover;
-  background-position: bottom;
-  background-repeat: repeat-x;
-`;
-
 const stepNumberCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.sub2Semibold};
-  color: ${theme.colors.primary.darknavy};
-  font-weight: 400;
-  margin: 0 0 8px 0;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -1.3px;
+  color: ${theme.colors.grey18[900]};
+  margin: 0;
 
-  ${mediaQuery('mobile')} {
-    font-size: 16px;
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 18px;
+    line-height: 1.4;
+    letter-spacing: 0;
   }
 `;
 
 const stepDescriptionCss = css`
-  ${theme.typosV3.pretendard.body1Medium};
+  font-family: 'Pretendard', sans-serif;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 1.4;
   color: ${colors.primary.blue};
-  font-weight: 400;
   margin: 0;
 
-  ${mediaQuery('mobile')} {
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 20px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
     font-size: 14px;
   }
 `;

--- a/src/components/PositionGrid/PositionCard.tsx
+++ b/src/components/PositionGrid/PositionCard.tsx
@@ -1,7 +1,7 @@
+import { useState } from 'react';
 import { css } from '@emotion/react';
 
 import useIsInProgress from '~/hooks/useIsInProgress';
-import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
 import { colors } from '../../styles/colors';
@@ -11,21 +11,22 @@ interface PositionCardProps {
   title: string;
   subtitle: string;
   isActive: boolean;
-  backgroundImage: string;
+  backgroundImage?: string;
   hoverDescription: string;
-  applyUrl: string;
+  applyUrl?: string;
 }
 
 export const PositionCard = ({
+  // id,
   title,
   subtitle,
   isActive,
-  backgroundImage,
+  // backgroundImage,
   hoverDescription,
   applyUrl,
 }: PositionCardProps) => {
   const { isInProgress } = useIsInProgress();
-  // const canApply = isAfterRecruitmentDate();
+  const [isHovered, setIsHovered] = useState(false);
 
   const handleCardClick = () => {
     if (isActive && applyUrl && isInProgress) {
@@ -35,236 +36,154 @@ export const PositionCard = ({
 
   return (
     <div
-      css={cardStyles(isActive, backgroundImage)}
+      css={cardStyles(isActive, isHovered)}
       className="position-card"
       onClick={handleCardClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
-      <div css={defaultContentStyles}>
-        <div css={contentStyles}>
-          <h3 css={titleStyles}>{title}</h3>
-          <p css={subtitleStyles}>{subtitle}</p>
-        </div>
-
-        {isInProgress ? (
-          <button css={applyButtonStyles}>
-            지원하기
-            <span css={arrowStyles}>→</span>
-          </button>
+      <div css={contentWrapperStyles}>
+        {isHovered ? (
+          <>
+            <h3 css={hoverTitleStyles}>{title}</h3>
+            <p css={hoverDescriptionStyles}>{hoverDescription}</p>
+          </>
         ) : (
-          <div css={beforeApplyButtonStyles}>지금은 지원 기간이 아니에요.</div>
-        )}
-      </div>
-
-      <div css={hoverContentStyles}>
-        <div css={hoverTextStyles}>{hoverDescription}</div>
-
-        {isInProgress ? (
-          <button css={hoverApplyButtonStyles}>
-            지원하기
-            <span css={hoverArrowStyles}>→</span>
-          </button>
-        ) : (
-          <div css={beforeApplyButtonStyles}>지금은 지원 기간이 아니에요.</div>
+          <>
+            <h3 css={titleStyles}>{title}</h3>
+            <p css={subtitleStyles}>{subtitle}</p>
+            <div css={iconPlaceholderStyles} />
+          </>
         )}
       </div>
     </div>
   );
 };
 
-const cardStyles = (isActive: boolean, backgroundImage: string) => css`
+const cardStyles = (isActive: boolean, isHovered: boolean) => css`
   position: relative;
-  background: ${colors.primary.gray};
-  background-image: url(${backgroundImage});
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  border: 1px solid ${isActive ? colors.blue500 : '#E0E0E0'};
-  border-radius: 0;
-  padding: 20px 22px;
-  width: 240px;
-  height: 302px;
+  background: ${isHovered ? '#2f3337' : colors.white};
+  border-radius: 12px;
+  padding: 24px;
+  width: 230px;
+  height: 320px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  overflow: hidden;
   cursor: ${isActive ? 'pointer' : 'default'};
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 1;
-    transition: background 0.3s ease;
-  }
+  transition: all 0.2s ease;
+  box-shadow: 0px 8px 32px 0px rgba(47, 51, 55, 0.1);
+  overflow: visible;
 
   &:hover {
-    box-shadow: ${isActive ? '0 8px 25px rgba(0,0,0,0.15)' : 'none'};
-    border-color: ${isActive ? '#1a1a1a' : isActive ? colors.blue500 : '#E0E0E0'};
-
-    &::before {
-      background: rgba(26, 26, 26, 1);
-    }
+    transform: ${isActive ? 'translateY(-4px)' : 'none'};
+    box-shadow: ${isActive
+      ? '0 8px 20px rgba(0, 100, 255, 0.15)'
+      : '0px 8px 32px 0px rgba(47, 51, 55, 0.1)'};
   }
 
-  ${mediaQuery('mobile')} {
-    width: 312px;
-    height: 300px;
+  @media (min-width: 1280px) and (max-width: 1919px) {
+    width: 285px;
+    height: 320px;
   }
 
-  ${mediaQuery('tablet')} {
-    width: 312px;
-    height: 300px;
+  @media (min-width: 768px) and (max-width: 1279px) {
+    width: 340px;
+    height: 320px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    width: 100%;
+    max-width: 340px;
+    height: 320px;
   }
 `;
 
-const defaultContentStyles = css`
-  position: absolute;
-  top: 24px;
-  left: 24px;
-  right: 24px;
-  bottom: 24px;
+const contentWrapperStyles = css`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  opacity: 1;
-  transition: opacity 0.3s ease;
-
-  .position-card:hover & {
-    opacity: 0;
-  }
-`;
-
-const contentStyles = css`
-  z-index: 2;
-  position: relative;
+  height: 100%;
+  gap: 12px;
+  align-items: flex-end;
 `;
 
 const titleStyles = css`
-  ${theme.typosV3.MartianMono.head3};
-  letter-spacing: -5%;
-
-  margin: 0 0 8px 0;
+  font-family: 'Helvetica Neue', 'Helvetica', 'Pretendard', sans-serif;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0;
   color: ${theme.colors.primary.darknavy};
-
-  ${mediaQuery('tablet')} {
-    ${theme.typosV3.MartianMono.head3};
-    font-size: 26px;
-    line-height: 125%;
-    letter-spacing: -1px;
-    white-space: pre-wrap;
-  }
+  white-space: pre-line;
+  letter-spacing: 0;
+  width: 100%;
+  min-width: 100%;
+  flex-shrink: 0;
 `;
 
 const subtitleStyles = css`
-  ${theme.typosV3.pretendard.sub5Medium};
-  color: ${colors.gray900};
-`;
-
-const applyButtonStyles = css`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: none;
-  border: none;
-  ${theme.typosV3.pretendard.sub1Medium};
-
-  color: ${colors.gray900};
-  cursor: pointer;
-  z-index: 2;
-  position: relative;
-
-  &:hover {
-    color: #000;
-  }
-`;
-
-const beforeApplyButtonStyles = css`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: none;
-  border: none;
-  font-size: 16px;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 20px;
   font-weight: 500;
-  color: #333;
-  cursor: pointer;
-  z-index: 2;
-  position: relative;
-  color: #9591a1;
-
-  &:hover {
-    color: #000;
-  }
+  line-height: 1.4;
+  margin: 0;
+  color: ${theme.colors.primary.darknavy};
+  letter-spacing: 0;
+  width: 100%;
+  height: 56px;
+  flex-shrink: 0;
 `;
 
-const hoverContentStyles = css`
-  position: absolute;
-  top: 24px;
-  left: 24px;
-  right: 24px;
-  bottom: 24px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  opacity: 0;
+// const imageContainerStyles = css`
+//   position: absolute;
+//   bottom: -10px;
+//   right: 0;
+//   left: 0;
+//   height: 180px;
+//   display: flex;
+//   align-items: flex-end;
+//   justify-content: center;
+//   padding-left: 20%;
+//   pointer-events: none;
+//   overflow: visible;
+// `;
 
-  .position-card:hover & {
-    opacity: 1;
-  }
+// const imageStyles = css`
+//   width: 160px;
+//   height: 160px;
+//   object-fit: contain;
+//   object-position: center;
+// `;
+
+const hoverTitleStyles = css`
+  font-family: 'Pretendard', sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.4;
+  margin: 0;
+  color: #f1f2f3;
+  letter-spacing: 0;
+  white-space: pre-line;
+  width: 100%;
+  min-width: 100%;
+  flex-shrink: 0;
 `;
 
-const hoverTextStyles = css`
-  ${theme.typosV3.pretendard.sub5Medium};
-
-  color: white;
+const hoverDescriptionStyles = css`
+  font-family: 'Pretendard', sans-serif;
   font-size: 14px;
-  z-index: 2;
-  position: relative;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0;
+  color: #f1f2f3;
+  letter-spacing: 0;
+  white-space: pre-wrap;
+  width: 100%;
+  flex-shrink: 0;
 `;
 
-// 이후 지원 버튼 추가 시 사용
-const hoverApplyButtonStyles = css`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: none;
-  border: none;
-  ${theme.typosV3.pretendard.sub1Medium};
-
-  color: white;
-  cursor: pointer;
-  z-index: 2;
-  position: relative;
-  transition: opacity 0.2s ease;
-
-  &:hover {
-    color: #ccc;
-  }
-`;
-
-const hoverArrowStyles = css`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  background: white;
-  color: ${colors.gray900};
-  border-radius: 50%;
-  font-size: 16px;
-`;
-
-const arrowStyles = css`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  background: ${colors.gray900};
-  color: white;
-  border-radius: 50%;
-  font-size: 16px;
+const iconPlaceholderStyles = css`
+  width: 116px;
+  height: 116px;
+  background: black;
+  flex-shrink: 0;
 `;

--- a/src/components/PositionGrid/PositionGrid.tsx
+++ b/src/components/PositionGrid/PositionGrid.tsx
@@ -1,71 +1,79 @@
+import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
-
-import { BlogRulerDecoration } from '~/features/Blog/sections/BlogRulerDecoration';
-import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
-import { mediaQuery } from '~/styles/media';
-import { theme } from '~/styles/theme';
 
 import { PositionCard } from './PositionCard';
 
 export const PositionGrid = () => {
-  const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
-  const { isTargetSize: isTabletSize } = useCheckWindowSize('tablet');
+  const [isTabletOrSmaller, setIsTabletOrSmaller] = useState(false);
+
+  useEffect(() => {
+    const checkSize = () => {
+      setIsTabletOrSmaller(window.innerWidth < 1280);
+    };
+
+    checkSize();
+    window.addEventListener('resize', checkSize);
+
+    return () => {
+      window.removeEventListener('resize', checkSize);
+    };
+  }, []);
   const positions = [
     {
       id: 'product-designer',
       title: 'Product \nDesigner',
       subtitle: '리서치·UX·UI·디자인시스템',
       isActive: true,
-      backgroundImage: !isMobileSize ? '/images/17th/sliced/i1.png' : '/images/17th/sliced/f1.png',
+      // backgroundImage: '/images/18th/3d-icon/design.png',
       hoverDescription:
         '프로덕트 디자이너로서 Figma를 이용해 화면을 디자인하고 개발자와 소통하며 프로덕트를 만듭니다. UX 리서치부터 UI 설계까지 사용자 중심의 사고로 제품 전반의 디자인을 주도하며, 논리적인 사고를 바탕으로 팀과 원활하게 협업합니다.',
-      applyUrl: 'https://01owexg4.ninehire.site/job_posting/Rc3jxbxM',
+      // applyUrl: 'https://01owexg4.ninehire.site/job_posting/Rc3jxbxM',
     },
     {
       id: 'android-developer',
       title: 'Android \nDeveloper',
       subtitle: 'Android·Kotlin·Git',
       isActive: true,
-      backgroundImage: !isMobileSize ? '/images/17th/sliced/i2.png' : '/images/17th/sliced/f2.png',
+      // backgroundImage: '/images/18th/3d-icon/and.png',
       hoverDescription:
         '안드로이드 개발자로서 Kotlin 언어에 대한 이해를 바탕으로, Jetpack Compose 또는 XML을 활용한 UI를 개발합니다. Retrofit 등의 서버 통신 경험과 안드로이드 생태계에 대한 이해를 바탕으로 서비스 흐름을 파악하고, 안정적인 앱 출시를 이끌어냅니다.',
-      applyUrl: 'https://01owexg4.ninehire.site/job_posting/pF3xSx1u',
+      // applyUrl: 'https://01owexg4.ninehire.site/job_posting/pF3xSx1u',
     },
     {
       id: 'ios-developer',
       title: 'iOS \nDeveloper',
       subtitle: 'iOS·Swift·Git',
       isActive: true,
-      backgroundImage: !isMobileSize ? '/images/17th/sliced/i3.png' : '/images/17th/sliced/f3.png',
+      // backgroundImage: '/images/18th/3d-icon/ios.png',
       hoverDescription:
         'iOS 개발자로서 Swift에 대한 이해를 바탕으로, UIKit 또는 SwiftUI를 활용한 UI를 개발합니다. URLSession, Alamofire, Moya 등을 이용한 API 통신 경험을 갖추고 있으며, 팀과 협업하여 앱스토어에 서비스를 성공적으로 배포합니다.',
-      applyUrl: 'https://01owexg4.ninehire.site/job_posting/GS3wiUKN',
+      // applyUrl: 'https://01owexg4.ninehire.site/job_posting/GS3wiUKN',
     },
     {
       id: 'server-developer',
       title: 'Server \nDeveloper',
       subtitle: 'Backend·Infra·Git',
       isActive: true,
-      backgroundImage: !isMobileSize ? '/images/17th/sliced/i4.png' : '/images/17th/sliced/f4.png',
+      // backgroundImage: '/images/18th/3d-icon/server.png',
       hoverDescription:
         '서버 개발자로서 프로젝트 초기 설계부터 인프라 구축까지 주도적으로 참여하며, 웹 서버 프레임워크를 활용해 프로덕트를 만듭니다. 프로덕트의 문제를 정의하고, 팀과의 협업을 통해 요구사항을 정리한 뒤, 이를 바탕으로 데이터 구조를 설계하고 구현합니다.',
-      applyUrl: 'https://01owexg4.ninehire.site/job_posting/1CM3XyoW',
+      // applyUrl: 'https://01owexg4.ninehire.site/job_posting/1CM3XyoW',
     },
     {
       id: 'web-developer',
       title: 'Web \nDeveloper',
       subtitle: 'Frontend·React·Git',
       isActive: true,
-      backgroundImage: !isMobileSize ? '/images/17th/sliced/i5.png' : '/images/17th/sliced/f5.png',
+      // backgroundImage: '/images/18th/3d-icon/web.png',
       hoverDescription:
         '웹 개발자로서 Git과 협업 도구에 익숙하며, HTTP 통신에 대한 기본적인 이해를 갖추고 있습니다. REST API 기반의 프론트엔드 개발 경험을 바탕으로 React, Vue, Angular 등 모던 자바스크립트 프레임워크를 활용해 사용자와 맞닿는 서비스를 구현합니다.',
-      applyUrl: 'https://01owexg4.ninehire.site/job_posting/ZcClQ2hr',
+      // applyUrl: 'https://01owexg4.ninehire.site/job_posting/ZcClQ2hr',
     },
   ];
 
   return (
     <>
-      {isTabletSize || isMobileSize ? (
+      {isTabletOrSmaller ? (
         <>
           <section css={sectionStyles}>
             <div css={mobileContainerStyles}>
@@ -74,19 +82,7 @@ export const PositionGrid = () => {
               <PositionCard {...positions[2]} />
               <PositionCard {...positions[3]} />
               <PositionCard {...positions[4]} />
-
-              {isMobileSize && (
-                <div css={recruitmentMobileMessageStyles}>
-                  디프만은 다섯개의 직군으로 구성되어 있어요.
-                </div>
-              )}
             </div>
-            {!isMobileSize && isTabletSize && (
-              <div css={recruitmentMobileMessageStyles}>
-                디프만은 다섯개의 직군으로 구성되어 있어요.
-              </div>
-            )}
-            <BlogRulerDecoration />
           </section>
         </>
       ) : (
@@ -94,22 +90,13 @@ export const PositionGrid = () => {
           <section css={sectionStyles}>
             <div css={containerStyles}>
               <div css={gridStyles}>
-                {/* 첫 번째 행: o o o x */}
                 <PositionCard {...positions[0]} />
                 <PositionCard {...positions[1]} />
                 <PositionCard {...positions[2]} />
-                <div css={emptySlotStyles}></div>
-
-                {/* 두 번째 행: x x o o */}
-                <div css={recruitmentMessageStyles}>
-                  디프만은 다섯개의 직군으로 구성되어 있어요.
-                </div>
-                <div css={emptySlotStyles}></div>
                 <PositionCard {...positions[3]} />
                 <PositionCard {...positions[4]} />
               </div>
             </div>
-            <BlogRulerDecoration />
           </section>
         </>
       )}
@@ -123,7 +110,6 @@ const sectionStyles = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-height: 100vh;
   gap: 36px;
 `;
 
@@ -137,71 +123,52 @@ const containerStyles = css`
 const mobileContainerStyles = css`
   display: grid;
   width: 100%;
-  grid-template-columns: repeat(2, auto);
+  max-width: 688px;
+  grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(3, auto);
-
-  align-items: center;
-
-  justify-items: center;
+  align-items: stretch;
+  justify-items: stretch;
   justify-content: center;
-
   padding: 24px 40px 0 40px;
-  gap: 20px;
+  gap: 8px;
+  margin: 0 auto;
 
-  ${mediaQuery('mobile')} {
+  @media (max-width: 767px) {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding-top: 24px;
+    padding: 24px 20px 0 20px;
     gap: 20px;
+    max-width: 100%;
   }
 `;
 
 const gridStyles = css`
   display: grid;
-  grid-template-columns: repeat(4, 240px);
-  grid-template-rows: repeat(2, 302px);
-  gap: 24px;
+  grid-template-columns: repeat(5, 230px);
+  gap: 12px;
   justify-content: center;
-`;
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
 
-const emptySlotStyles = css`
-  width: 240px;
-  height: 302px;
-`;
+  @media (min-width: 1280px) and (max-width: 1919px) {
+    grid-template-columns: repeat(6, 1fr);
+    gap: 12px;
+    max-width: 880px;
 
-const recruitmentMessageStyles = css`
-  width: 240px;
-  height: 302px;
-  display: flex;
-  align-items: flex-end;
-  font-size: 18px;
-  color: ${theme.colors.primary.darknavy};
-  line-height: 1.5;
-  font-weight: 500;
-  background: transparent;
-`;
+    & > div:nth-child(1),
+    & > div:nth-child(2),
+    & > div:nth-child(3) {
+      grid-column: span 2;
+    }
 
-const recruitmentMobileMessageStyles = css`
-  font-size: 18px;
-  color: ${theme.colors.primary.darknavy};
+    & > div:nth-child(4) {
+      grid-column: 2 / 4;
+    }
 
-  ${mediaQuery('tablet')} {
-    ${theme.typosV3.pretendard.sub1Medium};
-    width: 100%;
-    height: 100px;
-    display: flex;
-    padding-left: 62px;
-    margin-top: 40px;
-  }
-
-  ${mediaQuery('mobile')} {
-    width: 100%;
-    height: 100px;
-    display: flex;
-    padding-left: 24px;
-    line-height: 140%;
-    margin-top: 40px;
-    font-size: 16px;
+    & > div:nth-child(5) {
+      grid-column: 4 / 6;
+    }
   }
 `;

--- a/src/components/SessionSchedule/SessionSchedule.tsx
+++ b/src/components/SessionSchedule/SessionSchedule.tsx
@@ -1,328 +1,155 @@
+import { useEffect, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
-import { useCheckWindowSize } from '~/hooks/useCheckWindowSize';
-import { sectionBg } from '~/styles/background';
 import { colors } from '~/styles/colors';
-import { mediaQuery } from '~/styles/media';
 
-interface SessionData {
-  ot: string;
-  mini: string;
-  workshop: string;
-  currentMeeting: string;
-  teamBuilding: string;
+interface SessionItem {
+  date: string;
+  week: string;
+  title: string;
+  isOnline?: boolean;
 }
 
-interface OfflineSessionData {
-  utSharing: string;
-  hackathon: string;
-  teamBuilding: string;
-  presentationDay: string;
-  feedback: string;
-  networking: string;
-}
-
-interface FinalSessionData {
-  teamBuilding: string;
-  workOn: string;
-  teamBuilding2: string;
-  presentationDay: string;
-  finalPresentation: string;
-}
-
-const onlineSessionData: SessionData = {
-  ot: '08.02',
-  mini: '08.09',
-  currentMeeting: '08.16',
-  workshop: '08.23-24',
-  teamBuilding: '08.30',
-};
-
-const offlineSessionData: OfflineSessionData = {
-  utSharing: '09.06',
-  hackathon: '09.13',
-  teamBuilding: '09.20',
-  presentationDay: '09.27',
-  feedback: '10.11',
-  networking: '10.18',
-};
-
-const finalSessionData: FinalSessionData = {
-  teamBuilding: '10.25',
-  workOn: '11.01',
-  teamBuilding2: '11.08',
-  presentationDay: '11.15',
-  finalPresentation: '11.22',
-};
+const sessionScheduleData: SessionItem[] = [
+  { date: '03.14', week: '1주차', title: 'OT' },
+  { date: '03.21', week: '2주차', title: '아이디어 공유/피드백', isOnline: true },
+  { date: '03.28', week: '3주차', title: '현직자와의 만남' },
+  { date: '04.04', week: '4주차', title: '포커스 위크', isOnline: true },
+  { date: '04.11', week: '5주차', title: '중간 발표', isOnline: true },
+  { date: '04.18', week: '6주차', title: '캐주얼 네트워킹 세션' },
+  { date: '04.25', week: '7주차', title: '딮커톤' },
+  { date: '05.02', week: '8주차', title: '방학 🏄' },
+  { date: '05.09', week: '9주차', title: '프리 런칭 데이' },
+  { date: '05.16', week: '10주차', title: '딮크샵' },
+  { date: '05.23', week: '11주차', title: '포커스 위크', isOnline: true },
+  { date: '05.30', week: '12주차', title: '커리어 성장 세션' },
+  { date: '06.06', week: '13주차', title: '동문회' },
+  { date: '06.13', week: '14주차', title: '딮케이션' },
+  { date: '06.20', week: '15주차', title: '포커스 위크', isOnline: true },
+  { date: '06.27', week: '16주차', title: '런칭 데이' },
+  { date: '07.04', week: '17주차', title: '최종 발표' },
+];
 
 export const SessionSchedule = () => {
-  const { isTargetSize: isMobileSize } = useCheckWindowSize('mobile');
-  const { isTargetSize: isTabletSize } = useCheckWindowSize('tablet');
+  const [isLargeDesktop, setIsLargeDesktop] = useState(false);
+
+  useEffect(() => {
+    const checkScreenSize = () => {
+      setIsLargeDesktop(window.innerWidth >= 1920);
+    };
+
+    checkScreenSize();
+    window.addEventListener('resize', checkScreenSize);
+
+    return () => {
+      window.removeEventListener('resize', checkScreenSize);
+    };
+  }, []);
+
+  const shouldShowTwoColumns = isLargeDesktop;
+  const midPoint = Math.ceil(sessionScheduleData.length / 2);
+  const firstColumn = sessionScheduleData.slice(0, midPoint);
+  const secondColumn = sessionScheduleData.slice(midPoint);
 
   return (
-    <>
-      {!isTabletSize && !isMobileSize && (
-        <div css={containerCss}>
-          <div css={contentStyles}>
-            <div css={headerCss}>
-              <h2 css={titleCss}>온/오프라인 세션</h2>
-              <p css={descriptionCss}>
-                세션은 매주 토요일 진행되며,
-                <br /> 오프라인 세션은 서울에서 열립니다
-              </p>
-            </div>
+    <div css={containerCss}>
+      <div css={contentStyles}>
+        <div css={headerCss}>
+          <h2 css={titleCss}>온/오프라인 세션</h2>
+          <p css={descriptionCss}>
+            세션은 매주 토요일 진행되며,
+            <br />
+            오프라인 세션은 서울에서 열립니다
+          </p>
+        </div>
 
-            {/* 온라인 세션 테이블 */}
-            <div css={tableContainerCss}>
-              <table css={tableCss}>
-                <thead>
-                  <tr>
-                    <th css={[headerCellCss, darkHeaderCss]}>OT</th>
-                    <th css={headerCellCss}>미니 디프콘</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>현직자와의 만남</th>
-                    <th css={[headerCellCss, darkHeaderCss, whiteLineCss]}>딮크샵</th>
-                    <th css={headerCellCss}>팀별 작업</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{onlineSessionData.ot}</td>
-                    <td css={cellCss}>{onlineSessionData.mini}</td>
-                    <td css={cellCss}>{onlineSessionData.currentMeeting}</td>
-                    <td css={cellCss}>{onlineSessionData.workshop}</td>
-                    <td css={cellCss}>{onlineSessionData.teamBuilding}</td>
-                  </tr>
-                </tbody>
-              </table>
+        <div css={legendWrapperCss}>
+          <div css={onlineLegendCss}>
+            <div css={legendBadgeCss}>
+              <span css={legendBadgeTextCss}>온</span>
             </div>
-
-            {/* 오프라인 세션 테이블 */}
-            <div css={tableContainerCss}>
-              <table css={tableCss}>
-                <thead>
-                  <tr>
-                    <th css={[headerCellCss, darkHeaderCss]}>UT 결과 공유</th>
-                    <th css={[headerCellCss, darkHeaderCss, whiteLineCss]}>딮커톤</th>
-                    <th css={headerCellCss}>팀별 작업</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>프리런칭데이</th>
-                    <th css={headerCellCss}>피드백 공유</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>반상회</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{offlineSessionData.utSharing}</td>
-                    <td css={cellCss}>{offlineSessionData.hackathon}</td>
-                    <td css={cellCss}>{offlineSessionData.teamBuilding}</td>
-                    <td css={cellCss}>{offlineSessionData.presentationDay}</td>
-                    <td css={cellCss}>{offlineSessionData.feedback}</td>
-                    <td css={cellCss}>{offlineSessionData.networking}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* 최종 세션 테이블 */}
-            <div css={tableContainerCss}>
-              <table css={tableCss}>
-                <thead>
-                  <tr>
-                    <th css={headerCellCss}>팀별 작업</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>딮케이션</th>
-                    <th css={headerCellCss}>팀별 작업</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>런칭데이</th>
-                    <th css={[headerCellCss, darkHeaderCss, whiteLineCss]}>최종 발표</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{finalSessionData.teamBuilding}</td>
-                    <td css={cellCss}>{finalSessionData.workOn}</td>
-                    <td css={cellCss}>{finalSessionData.teamBuilding2}</td>
-                    <td css={cellCss}>{finalSessionData.presentationDay}</td>
-                    <td css={cellCss}>{finalSessionData.finalPresentation}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* 세션 타입 표시 */}
-            <div css={sessionTypeCss}>
-              <div css={sessionItemCss}>
-                <div css={filledCircleCss} />
-                <span css={sessionTextCss}>오프라인 세션</span>
-              </div>
-              <div css={sessionItemCss}>
-                <div css={emptyCircleCss} />
-                <span css={sessionTextCss}>온라인 세션</span>
-              </div>
-            </div>
+            <span css={legendTextCss}>: 온라인 세션</span>
           </div>
         </div>
-      )}
-      {(isTabletSize || isMobileSize) && (
-        <div css={containerCss}>
-          <div css={contentStyles}>
-            <div css={headerCss}>
-              <h2 css={titleCss}>온/오프라인 세션</h2>
-              <p css={descriptionCss}>
-                {`세션은 매주 토요일 진행되며, \n오프라인 세션은 서울에서 열립니다`}
-              </p>
-            </div>
 
-            {/* 첫 번째 테이블: OT, 아이디어 공유, 워크샵 */}
-            <div css={tableContainerCss}>
-              <table css={tableCss}>
-                <thead>
-                  <tr>
-                    <th css={[headerCellCss, darkHeaderCss]}>OT</th>
-                    <th css={headerCellCss}>미니 디프콘</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>현직자와의 만남</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{onlineSessionData.ot}</td>
-                    <td css={cellCss}>{onlineSessionData.mini}</td>
-                    <td css={cellCss}>{onlineSessionData.currentMeeting}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* 두 번째 테이블: 현직자와의 만남, 팀별 작업, UT 결과 공유 */}
-            <div css={tableContainerCss}>
-              <table css={tableCss}>
-                <thead>
-                  <tr>
-                    <th css={[headerCellCss, darkHeaderCss]}>딮크샵</th>
-                    <th css={headerCellCss}>팀별 작업</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>UT 결과 공유</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{onlineSessionData.workshop}</td>
-                    <td css={cellCss}>{onlineSessionData.teamBuilding}</td>
-                    <td css={cellCss}>{offlineSessionData.utSharing}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* 세 번째 테이블: 딮커톤, 팀별 작업, 프리런칭데이 */}
-            <div css={tableContainerCss}>
-              <table css={tableCss}>
-                <thead>
-                  <tr>
-                    <th css={[headerCellCss, darkHeaderCss]}>딮커톤</th>
-                    <th css={headerCellCss}>팀별 작업</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>프리런칭데이</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{offlineSessionData.hackathon}</td>
-                    <td css={cellCss}>{offlineSessionData.teamBuilding}</td>
-                    <td css={cellCss}>{offlineSessionData.presentationDay}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* 네 번째 테이블: 피드백 공유, 반상회, 팀별 작업 */}
-            <div css={tableContainerCss}>
-              <table css={tableCss}>
-                <thead>
-                  <tr>
-                    <th css={headerCellCss}>피드백 공유</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>반상회</th>
-                    <th css={headerCellCss}>팀별 작업</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{offlineSessionData.feedback}</td>
-                    <td css={cellCss}>{offlineSessionData.networking}</td>
-                    <td css={cellCss}>{finalSessionData.teamBuilding}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* 다섯 번째 테이블: 딮케이션, 팀별 작업, 런칭데이, 최종 발표 */}
-            <div css={tableContainerCss}>
-              <table css={finalTableCss}>
-                <thead>
-                  <tr>
-                    <th css={[headerCellCss, darkHeaderCss]}>딮케이션</th>
-                    <th css={headerCellCss}>팀별 작업</th>
-                    <th css={[headerCellCss, darkHeaderCss]}>런칭데이</th>
-                    <th css={[headerCellCss, darkHeaderCss, whiteLineCss]}>최종 발표</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td css={cellCss}>{finalSessionData.workOn}</td>
-                    <td css={cellCss}>{finalSessionData.teamBuilding2}</td>
-                    <td css={cellCss}>{finalSessionData.presentationDay}</td>
-                    <td css={cellCss}>{finalSessionData.finalPresentation}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* 세션 타입 표시 */}
-            <div css={sessionTypeCss}>
-              <div css={sessionItemCss}>
-                <div css={filledCircleCss} />
-                <span css={sessionTextCss}>오프라인 세션</span>
+        <div css={sessionCardCss}>
+          {shouldShowTwoColumns ? (
+            <div css={twoColumnGridCss}>
+              <div css={columnCss}>
+                {firstColumn.map((session, index) => (
+                  <div key={index} css={sessionItemCss(index === firstColumn.length - 1)}>
+                    <div css={dateWeekContainerCss}>
+                      <p css={dateTextCss}>{session.date}</p>
+                      <p css={weekTextCss}>{session.week}</p>
+                    </div>
+                    <div css={programContainerCss}>
+                      <p css={titleTextCss}>{session.title}</p>
+                      {session.isOnline && (
+                        <div css={onlineBadgeCss}>
+                          <span css={badgeTextCss}>온</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
               </div>
-              <div css={sessionItemCss}>
-                <div css={emptyCircleCss} />
-                <span css={sessionTextCss}>온라인 세션</span>
+              <div css={columnCss}>
+                {secondColumn.map((session, index) => (
+                  <div key={index} css={sessionItemCss(index === secondColumn.length - 1)}>
+                    <div css={dateWeekContainerCss}>
+                      <p css={dateTextCss}>{session.date}</p>
+                      <p css={weekTextCss}>{session.week}</p>
+                    </div>
+                    <div css={programContainerCss}>
+                      <p css={titleTextCss}>{session.title}</p>
+                      {session.isOnline && (
+                        <div css={onlineBadgeCss}>
+                          <span css={badgeTextCss}>온</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
-          </div>
+          ) : (
+            <div css={singleColumnCss}>
+              {sessionScheduleData.map((session, index) => (
+                <div key={index} css={sessionItemCss(index === sessionScheduleData.length - 1)}>
+                  <div css={dateWeekContainerCss}>
+                    <p css={dateTextCss}>{session.date}</p>
+                    <p css={weekTextCss}>{session.week}</p>
+                  </div>
+                  <div css={programContainerCss}>
+                    <p css={titleTextCss}>{session.title}</p>
+                    {session.isOnline && (
+                      <div css={onlineBadgeCss}>
+                        <span css={badgeTextCss}>온</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
-      )}
-    </>
+      </div>
+    </div>
   );
 };
 
-const containerCss = (theme: Theme) => css`
+const containerCss = (_theme: Theme) => css`
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 100%;
   margin: 0 auto;
-  padding: 80px 20px;
-  background-color: ${theme.colors.primary.gray};
-  ${sectionBg};
+  padding: 120px 20px;
+  background-color: ${colors.grey18[900]};
 
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: -100px;
-    left: 0;
-    width: 353px;
-    height: 353px;
-    background-image: url('/images/17th/shapes/yellow.png');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: bottom left;
-    z-index: 0;
-    opacity: 1;
-
-    ${mediaQuery('mobile')} {
-      width: 200px;
-      height: 200px;
-    }
-    ${mediaQuery('tablet')} {
-      width: 200px;
-      height: 200px;
-    }
+  @media (max-width: 767px) {
+    padding: 80px 20px;
   }
 `;
 
@@ -333,210 +160,273 @@ const contentStyles = css`
   flex-direction: column;
   align-items: center;
   width: 100%;
-  max-width: 1100px;
+  max-width: 1200px;
+
+  @media (min-width: 1920px) {
+    max-width: 1200px;
+  }
+
+  @media (min-width: 1280px) and (max-width: 1919px) {
+    max-width: 600px;
+  }
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    max-width: 600px;
+  }
+
+  @media (max-width: 767px) {
+    max-width: 100%;
+  }
 `;
 
 const headerCss = css`
   text-align: center;
-  margin-bottom: 60px;
+  margin-bottom: 40px;
 
-  ${mediaQuery('mobile')} {
-    margin-bottom: 40px;
+  @media (max-width: 767px) {
+    margin-bottom: 30px;
   }
 `;
 
-const titleCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.head1};
-  color: ${theme.colors.primary.darknavy};
+const titleCss = css`
+  color: ${colors.white};
   margin-bottom: 16px;
   font-size: 36px;
-  font-weight: 600;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
 
-  ${mediaQuery('mobile')} {
-    font-size: 1.5rem;
-  }
-
-  ${mediaQuery('tablet')} {
-    font-size: 1.5rem;
-  }
-`;
-
-const descriptionCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.sub1Semibold};
-  color: ${theme.colors.primary.darknavy};
-  font-size: 20px;
-  font-weight: 400;
-  ${mediaQuery('mobile')} {
-    font-size: 0.875rem;
-    white-space: pre-wrap;
+  @media (max-width: 767px) {
+    font-size: 26px;
+    line-height: 1.25;
+    letter-spacing: -0.05em;
   }
 `;
 
-const tableContainerCss = css`
-  margin-bottom: 40px;
-  overflow-x: auto;
+const descriptionCss = css`
+  color: ${colors.white};
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0;
 
-  ${mediaQuery('mobile')} {
-    margin-bottom: 30px;
-  }
-
-  ${mediaQuery('tablet')} {
-    margin-bottom: 30px;
+  @media (max-width: 767px) {
+    font-size: 14px;
   }
 `;
 
-const tableCss = css`
+const legendWrapperCss = css`
   width: 100%;
-  border-collapse: collapse;
-  background-color: white;
-  border: 1px solid ${colors.primary.darknavy};
-
-  ${mediaQuery('mobile')} {
-    width: 328px;
-  }
-  ${mediaQuery('tablet')} {
-    width: 328px;
-  }
-`;
-
-const finalTableCss = css`
-  width: 100%;
-  border-collapse: collapse;
-  background-color: white;
-  border: 1px solid ${colors.primary.darknavy};
-
-  ${mediaQuery('mobile')} {
-    width: 328px;
-  }
-  ${mediaQuery('tablet')} {
-    width: 328px;
-  }
-`;
-
-const headerCellCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.sub3Semibold};
-
-  width: 134.86px;
-  min-width: 134.86px;
-  max-width: 134.86px;
-  padding: 16px 12px;
-  text-align: center;
-  font-weight: 600;
-  background-color: ${theme.colors.primary.gray};
-  color: ${theme.colors.primary.darknavy};
-  border: 1px solid ${colors.primary.darknavy};
-
-  ${mediaQuery('mobile')} {
-    width: 110px;
-    min-width: 110px;
-    max-width: 110px;
-    padding: 12px 8px;
-    font-size: 0.875rem;
-  }
-
-  ${mediaQuery('tablet')} {
-    width: 82px;
-    min-width: 82px;
-    max-width: 82px;
-    padding: 12px 8px;
-    font-size: 0.875rem;
-  }
-`;
-
-const darkHeaderCss = css`
-  background-color: ${colors.primary.darknavy};
-  color: white;
-  border: 1px solid ${colors.primary.darknavy};
-`;
-
-const whiteLineCss = css`
-  position: relative;
-  border-left: none !important;
-
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 2px;
-    bottom: 2px;
-    width: 1px;
-    background-color: ${colors.primary.gray};
-  }
-`;
-
-const cellCss = (theme: Theme) => css`
-  ${theme.typosV3.pretendard.body3Medium};
-
-  width: 134.86px;
-  min-width: 134.86px;
-  max-width: 134.86px;
-  padding: 16px 12px;
-  text-align: center;
-  background: ${colors.primary.gray};
-  color: ${theme.colors.primary.darknavy};
-
-  ${mediaQuery('mobile')} {
-    padding: 12px 8px;
-    font-size: 0.875rem;
-    width: 110px;
-    min-width: 82px;
-    max-width: 110px;
-  }
-  ${mediaQuery('tablet')} {
-    padding: 12px 8px;
-    font-size: 0.875rem;
-    width: 110px;
-    min-width: 82px;
-    max-width: 110px;
-  }
-`;
-
-const sessionTypeCss = css`
   display: flex;
-  justify-content: center;
-  gap: 40px;
-  margin-top: 40px;
+  justify-content: flex-end;
+  margin-bottom: 16px;
 
-  ${mediaQuery('mobile')} {
-    gap: 20px;
-    margin-top: 30px;
-  }
-  ${mediaQuery('tablet')} {
-    gap: 20px;
-    margin-top: 30px;
+  @media (max-width: 767px) {
+    margin-bottom: 12px;
   }
 `;
 
-const sessionItemCss = css`
+const onlineLegendCss = css`
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 `;
 
-const filledCircleCss = css`
-  width: 20px;
-  height: 20px;
+const legendBadgeCss = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  background-color: ${colors.primary.darknavy};
-`;
+  background-color: ${colors.primary.blue};
+  flex-shrink: 0;
 
-const emptyCircleCss = css`
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: 2px solid ${colors.primary.darknavy};
-  background-color: ${colors.primary.gray};
-`;
-
-const sessionTextCss = (theme: Theme) => css`
-  ${theme.typosV2.pretendard.regular14};
-  color: ${theme.colors.grey['900']};
-  font-weight: 500;
-
-  ${mediaQuery('mobile')} {
-    font-size: 0.875rem;
+  @media (max-width: 767px) {
+    width: 18px;
+    height: 18px;
   }
-  ${mediaQuery('tablet')} {
-    font-size: 0.875rem;
+`;
+
+const legendBadgeTextCss = css`
+  font-size: 10.909px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  color: ${colors.white};
+  text-align: center;
+
+  @media (max-width: 767px) {
+    font-size: 8.1px;
+    font-weight: 500;
+    line-height: 1.5;
+    letter-spacing: -0.02em;
+  }
+`;
+
+const legendTextCss = css`
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.4;
+  color: ${colors.white};
+
+  @media (max-width: 767px) {
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.5;
+    letter-spacing: -0.01em;
+  }
+`;
+
+const sessionCardCss = css`
+  background: ${colors.white};
+  border-radius: 48px;
+  padding: 56px 72px;
+  width: 100%;
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    border-radius: 40px;
+    padding: 56px 72px;
+  }
+
+  @media (max-width: 767px) {
+    padding: 16px 20px;
+    border-radius: 20px;
+  }
+`;
+
+const twoColumnGridCss = css`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 40px;
+  width: 100%;
+`;
+
+const columnCss = css`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const singleColumnCss = css`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const sessionItemCss = (isLast: boolean) => css`
+  display: flex;
+  align-items: flex-end;
+  gap: 40px;
+  padding: 24px 40px 20px 0;
+  border-bottom: ${isLast ? 'none' : `1px solid ${colors.grey18[300]}`};
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    gap: 24px;
+    padding: 12px 0;
+  }
+`;
+
+const dateWeekContainerCss = css`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 105px;
+  flex-shrink: 0;
+
+  @media (max-width: 767px) {
+    width: 48px;
+  }
+`;
+
+const dateTextCss = css`
+  font-family: 'Pretendard', sans-serif;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: ${colors.grey18[900]};
+  text-align: left;
+  margin: 0;
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 12px;
+    line-height: 1.5;
+    letter-spacing: -0.12px;
+  }
+`;
+
+const weekTextCss = css`
+  font-family: 'Pretendard', sans-serif;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: -0.64px;
+  color: ${colors.grey18[700]};
+  margin: 0;
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 15px;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+`;
+
+const programContainerCss = css`
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  flex: 1;
+
+  @media (max-width: 767px) {
+    gap: 8px;
+    align-items: center;
+  }
+`;
+
+const titleTextCss = css`
+  font-family: 'Pretendard', sans-serif;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: -0.64px;
+  color: ${colors.grey18[900]};
+  margin: 0;
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 15px;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+`;
+
+const onlineBadgeCss = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: ${colors.primary.blue};
+  flex-shrink: 0;
+
+  @media (max-width: 767px) {
+    width: 18px;
+    height: 18px;
+  }
+`;
+
+const badgeTextCss = css`
+  font-size: 18.182px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  color: ${colors.white};
+  text-align: center;
+
+  @media (max-width: 767px) {
+    font-size: 8.1px;
+    font-weight: 500;
+    line-height: 1.5;
+    letter-spacing: -0.02em;
   }
 `;

--- a/src/components/ValueSection/ValueSection.tsx
+++ b/src/components/ValueSection/ValueSection.tsx
@@ -1,40 +1,54 @@
 import { css } from '@emotion/react';
 
-import { sectionBg } from '~/styles/background';
 import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
-import { colors } from '../../styles/colors';
+const CARD_GRADIENT_START = '#DFEEFE';
+const CARD_GRADIENT_END = '#F9FBFF';
 
 export const ValueSection = () => {
   const values = [
     {
       id: 'responsibility',
-      title: 'Responsibility & Ownership',
-      description: '서비스에 책임감을 갖고, 주인의식을 바탕으로 끝까지 해내는 사람',
+      number: '01',
+      title: '책임감',
+      subtitle: 'Responsibility',
+      description: '맡은 일의 크기와 상관없이\n끝까지 완수하려는 태도',
     },
     {
-      id: 'collaboration',
-      title: 'Collaboration & Sharing',
-      description: '의견을 존중하며 적극적으로 소통하고, 지식과 경험을 나누며 함께 성장하는 사람',
+      id: 'ownership',
+      number: '02',
+      title: '오너쉽',
+      subtitle: 'Ownership',
+      description: '문제와 결과를 내 일처럼\n받아들이는 태도',
     },
     {
-      id: 'passion',
-      title: 'Passion & Adventure',
-      description: '새로운 도전을 즐기며, 열정을 가지고 주도적으로 해결책을 찾아나가는 사람',
+      id: 'flexibility',
+      number: '03',
+      title: '유연성',
+      subtitle: 'Flexibility',
+      description: '완벽한 계획보다 빠른 실행과\n실험을 통해 배우는 태도',
     },
   ];
 
   return (
     <div css={containerStyles}>
       <div css={contentStyles}>
-        <div css={titleStyles}>17기의 인재상</div>
-        {values.map(value => (
-          <div key={value.id} css={valueCardStyles}>
-            <h3 css={semititleStyles}>{value.title}</h3>
-            <p css={descriptionStyles}>{value.description}</p>
-          </div>
-        ))}
+        <div css={headerContainerStyles}>
+          <div css={titleStyles}>18기의 인재상</div>
+          <div css={subtitleStyles}>디프만은 이런 디퍼를 원해요</div>
+        </div>
+        <div css={cardsContainerStyles}>
+          {values.map(value => (
+            <div key={value.id} css={valueCardStyles}>
+              <div css={numberStyles}>{value.number}</div>
+              {/* <div css={cardImagePlaceholderStyles}></div> */}
+              <h3 css={semititleStyles}>{value.title}</h3>
+              <p css={cardSubtitleStyles}>{value.subtitle}</p>
+              <p css={descriptionStyles}>{value.description}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );
@@ -49,7 +63,6 @@ const containerStyles = css`
   gap: 16px;
   margin: 0 auto;
   padding: 120px 20px;
-  ${sectionBg};
 
   ${mediaQuery('tablet')} {
     overflow-x: hidden;
@@ -57,7 +70,6 @@ const containerStyles = css`
     padding: 120px 20px 200px 20px;
   }
   ${mediaQuery('mobile')} {
-    /* overflow: auto; */
     padding: 120px 20px;
   }
 
@@ -68,10 +80,6 @@ const containerStyles = css`
     right: 50px;
     width: 282px;
     height: 282px;
-    background-image: url('/images/17th/shapes/compass.png');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: top right;
     z-index: 0;
     opacity: 1;
 
@@ -93,10 +101,6 @@ const containerStyles = css`
     left: -50px;
     width: 312px;
     height: 312px;
-    background-image: url('/images/17th/shapes/pink_arrow.png');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: bottom left;
     z-index: 3;
     opacity: 1;
 
@@ -121,70 +125,163 @@ const contentStyles = css`
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 40px;
   width: 100%;
   max-width: 1100px;
   align-items: center;
+
+  ${mediaQuery('mobile')} {
+    gap: 30px;
+  }
 `;
 
-const valueCardStyles = css`
-  background: ${colors.white};
-  border: 1px solid ${colors.blue500};
-  padding: 28px 26px;
+const headerContainerStyles = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
   text-align: center;
-  transition: all 0.2s ease;
-  width: 730px;
-  background: ${colors.primary.gray};
-
-  ${mediaQuery('tablet')} {
-    width: 100%;
-    margin: 0 40.5px;
-  }
-  ${mediaQuery('mobile')} {
-    width: 328px;
-  }
 `;
 
 const titleStyles = css`
   ${theme.typosV3.pretendard.head1};
+  font-size: 36px;
   font-weight: 600;
-  margin: 0 0 16px 0;
+  margin: 0;
+  color: ${theme.colors.primary.darknavy};
+
+  ${mediaQuery('mobile')} {
+    font-size: 28px;
+  }
+`;
+
+const subtitleStyles = css`
+  ${theme.typosV3.pretendard.sub1Semibold};
+  font-size: 18px;
+  font-weight: 400;
+  margin: 0;
+  color: ${theme.colors.primary.darknavy};
+
+  ${mediaQuery('mobile')} {
+    font-size: 14px;
+  }
+`;
+
+const cardsContainerStyles = css`
+  display: grid;
+  grid-template-columns: repeat(3, 392px);
+  gap: 12px;
+  width: 100%;
+  justify-content: center;
+
+  @media (min-width: 1280px) and (max-width: 1919px) {
+    grid-template-columns: repeat(3, 285px);
+  }
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    grid-template-columns: repeat(3, 224px);
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    grid-template-columns: 320px;
+  }
+`;
+
+const valueCardStyles = css`
+  background: linear-gradient(to bottom right, ${CARD_GRADIENT_START}, ${CARD_GRADIENT_END});
+  clip-path: polygon(70px 0%, 100% 0%, 100% 100%, 0% 100%, 0% 70px);
+  border-radius: 16px;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 8px;
+  position: relative;
+  width: 392px;
+  height: 400px;
+
+  @media (min-width: 1280px) and (max-width: 1919px) {
+    width: 285px;
+    height: 380px;
+    padding: 32px;
+  }
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    width: 224px;
+    height: 320px;
+    padding: 28px;
+    border-radius: 12px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    width: 320px;
+    height: 320px;
+    padding: 28px;
+    border-radius: 12px;
+  }
+`;
+
+const numberStyles = css`
+  font-family: 'Helvetica Neue', sans-serif;
+  font-size: 40px;
+  font-weight: 700;
+  color: ${theme.colors.grey18[400]};
+  line-height: 1.4;
+  letter-spacing: -0.4px;
+  position: absolute;
+  top: 20px;
+  right: 42.5px;
+  transform: translateX(50%);
   text-align: center;
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 32px;
+    line-height: 1.2;
+    right: 38px;
+  }
 `;
 
 const semititleStyles = css`
-  ${theme.typosV3.MartianMono.head3};
-  font-weight: 500;
-  letter-spacing: -4%;
-  line-height: 109%;
-  margin: 0 0 16px 0;
-  line-height: 1.2;
-  text-align: center;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 36px;
+  font-weight: 700;
+  color: ${theme.colors.primary18.strong};
+  margin: 0;
+  line-height: 1.4;
+  letter-spacing: -0.36px;
 
-  ${mediaQuery('tablet')} {
-    font-weight: 400;
-    font-size: 28px;
-    letter-spacing: -1px;
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 32px;
+    letter-spacing: -0.64px;
   }
-  ${mediaQuery('mobile')} {
-    ${theme.typosV3.MartianMono.body2};
+`;
+
+const cardSubtitleStyles = css`
+  font-family: 'Helvetica Neue', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  color: ${theme.colors.grey18[900]};
+  margin: 0;
+  line-height: 1.4;
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 18px;
     font-weight: 500;
-    font-size: 17px;
+    line-height: 1.6;
+    letter-spacing: -0.18px;
   }
 `;
 
 const descriptionStyles = css`
-  ${theme.typosV3.pretendard.sub2Semibold};
+  font-family: 'Pretendard', sans-serif;
+  font-size: 24px;
   font-weight: 500;
-
+  color: ${theme.colors.grey18[900]};
   margin: 0;
-  line-height: 1.5;
+  line-height: 1.4;
+  white-space: pre-line;
 
-  ${mediaQuery('tablet')} {
-    font-weight: 400;
-  }
-  ${mediaQuery('mobile')} {
-    ${theme.typosV3.pretendard.sub4Semibold};
-    font-weight: 500;
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 18px;
   }
 `;

--- a/src/features/Recruit/sections/RecruitIntroSection.tsx
+++ b/src/features/Recruit/sections/RecruitIntroSection.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { PositionGrid } from '~/components/PositionGrid/PositionGrid';
-import { sectionGridBg } from '~/styles/background';
 
 import { RecruitTitleSection } from './RecruitTitleSection';
 
@@ -16,6 +15,20 @@ export function RecruitIntroSection() {
 
 const sectionCss = css`
   position: relative;
+  background: linear-gradient(to bottom, #5aafff, #dfeeff);
+  display: flex;
+  flex-direction: column;
+  padding: 120px 0 160px 0;
 
-  ${sectionGridBg}
+  @media (min-width: 1280px) and (max-width: 1919px) {
+    padding: 120px 0 120px 0;
+  }
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    padding: 60px 40px 80px 40px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    padding: 28px 20px 40px 20px;
+  }
 `;

--- a/src/features/Recruit/sections/RecruitTitleSection.tsx
+++ b/src/features/Recruit/sections/RecruitTitleSection.tsx
@@ -1,27 +1,17 @@
-import Image from 'next/image';
 import { css } from '@emotion/react';
 
-import { mediaQuery } from '~/styles/media';
 import { theme } from '~/styles/theme';
 
 export function RecruitTitleSection() {
   return (
     <section css={sectionCss}>
-      <div>
-        <h1 id="title">
-          <Image
-            width={530}
-            height={84}
-            src="/images/17th/recruitment-title.svg"
-            alt="디프만 17기 모집 안내"
-            css={imageCss}
-          />
+      <div css={contentWrapperCss}>
+        <h1 id="title" css={titleTextCss}>
+          Recruitment
         </h1>
-      </div>
-      <div css={descriptionCss}>
-        <div>2025.06.30 - 07.06</div>
-        <div>
-          <span>depromeet 17.0</span>
+        <div css={descriptionCss}>
+          <span>2026.02.12 - 02.18</span>
+          <span>depromeet 18.0</span>
         </div>
       </div>
     </section>
@@ -30,59 +20,74 @@ export function RecruitTitleSection() {
 
 const sectionCss = css`
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: relative;
+  justify-content: center;
   width: 100%;
-  gap: 36px;
+  padding: 100px 20px 40px;
 
-  & > div {
-    width: 100%;
-    max-width: 1100px;
-  }
-
-  & #title {
-    padding: 103px 48px 26px;
-
-    ${mediaQuery('mobile')} {
-      padding: 76px 24px 16px;
-    }
-  }
-
-  ${mediaQuery('mobile')} {
-    gap: 0px;
+  @media (max-width: 768px) {
+    padding: 60px 20px 30px;
   }
 `;
 
-const imageCss = css`
-  ${mediaQuery('mobile')} {
-    width: 248.438px;
-    height: 39.375px;
+const contentWrapperCss = css`
+  width: 100%;
+  max-width: 1200px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+
+  @media (min-width: 1280px) and (max-width: 1919px) {
+    max-width: 880px;
+  }
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    max-width: 688px;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    max-width: 688px;
+  }
+`;
+
+const titleTextCss = css`
+  font-family: 'Helvetica Neue', 'Pretendard', sans-serif;
+  font-size: 88px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: ${theme.colors.white};
+  margin: 0;
+  letter-spacing: -0.04em;
+
+  @media (min-width: 768px) and (max-width: 1279px) {
+    font-size: 60px;
+    line-height: 1.4;
+    letter-spacing: -0.01em;
+  }
+
+  @media (min-width: 360px) and (max-width: 767px) {
+    font-size: 40px;
+    line-height: 1.4;
+    letter-spacing: -0.01em;
   }
 `;
 
 const descriptionCss = css`
   display: flex;
-  gap: 68px;
-  width: 100%;
-  max-width: 1100px;
-  padding: 0 48px;
-  color: ${theme.colors.primary.darknavy};
-  ${theme.typosV3.MartianMono.body2}
+  align-items: center;
+  gap: 28px;
+  color: ${theme.colors.white};
+  font-family: 'Helvetica Neue', 'Pretendard', sans-serif;
+  font-size: 40px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
 
-  & > div {
-    width: fit-content;
-    padding: 4px 0;
-    background-color: ${theme.colors.primary.gray};
-  }
-
-  & > span {
-    padding: 9px;
-  }
-
-  ${mediaQuery('mobile')} {
+  @media (min-width: 360px) and (max-width: 767px) {
     flex-direction: column;
+    align-items: flex-start;
     gap: 4px;
-    padding: 0 24px;
+    font-size: 20px;
+    letter-spacing: 0;
   }
 `;

--- a/src/pages/recruit.tsx
+++ b/src/pages/recruit.tsx
@@ -1,7 +1,4 @@
-import { ContactSection } from '~/components/ContactSection/ContactSection';
-import { FAQ } from '~/components/FAQ';
 import { MemberRecruitment } from '~/components/MemberRecruitment';
-import { Review } from '~/components/Review';
 import { SEO } from '~/components/SEO';
 import { SessionSchedule } from '~/components/SessionSchedule';
 import { ValueSection } from '~/components/ValueSection';
@@ -16,9 +13,6 @@ export default function Recruit() {
         <ValueSection />
         <MemberRecruitment />
         <SessionSchedule />
-        <Review />
-        <FAQ />
-        <ContactSection />
       </main>
     </>
   );


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
### 📌 작업 개요
- 18기 모집 안내 페이지에 대해 직군별 카드, 상단 안내 영역, 인재상, 모집 일정 및 세션 정보 등 전반적인 UI/UX 디자인을 반영했습니다.

### ✨ 주요 변경 사항

- PositionCard: 직군별 카드 디자인 반영
- PositionGrid: 직군 카드 그리드 레이아웃 구성 및 반응형 정렬

- RecruitTitleSection: 18기 모집 안내 상단 섹션 디자인 반영 & 타이틀/설명 영역 시각적 구조 개선

- ValueSection: 18기 인재상 디자인 및 문구 반영

- MemberRecruitment: 모집 일정 섹션 디자인 및 내용 반영

- SessionSchedule: 온·오프라인 세션 일정 UI 구성

- chore(recruit): 모집 안내 페이지에서 사용하지 않는 컴포넌트 제거

### 참고
- MemberRecruitment에서 사용하는 화살표 ui 수정 예정

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
