### PR TITLE
feat: 홈 화면 UI 개선 및 브라우저별 영상 분기

### DIFF
--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -41,6 +41,11 @@ const linkButtonCss = css`
   font-weight: 700;
   line-height: normal;
 
+  /* Tablet: Push button to right */
+  @media (min-width: 768px) and (max-width: 1279px) {
+    margin-left: auto;
+  }
+
   &:disabled {
     background: ${colors.grey[300]};
     color: ${colors.grey[500]};
@@ -124,7 +129,8 @@ const navCss = (isPastHero: boolean) => css`
   ${navCommonCss()};
   background: ${isPastHero ? 'rgba(255, 255, 255, 0.1)' : 'transparent'};
   backdrop-filter: ${isPastHero ? 'blur(10px)' : 'none'};
-  padding: 40px 20px 0 20px;
+  height: 80px;
+  padding: 0 40px;
   transition: background 0.3s ease, backdrop-filter 0.3s ease;
 
   display: none;
@@ -133,7 +139,6 @@ const navCss = (isPastHero: boolean) => css`
 
   @media (min-width: 768px) {
     display: flex;
-    padding: 40px 40px 0 40px;
   }
 `;
 
@@ -148,8 +153,18 @@ const mobileNavCss = css`
 const navWrapperCss = css`
   width: 100%;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+
+  /* Tablet: Logo and Menu grouped on left */
+  @media (min-width: 768px) and (max-width: 1279px) {
+    justify-content: flex-start;
+    gap: 40px;
+  }
+
+  /* Desktop: Logo left, Menu center, Button right */
+  @media (min-width: 1280px) {
+    justify-content: space-between;
+  }
 `;
 
 const logoLinkCss = css`
@@ -222,7 +237,8 @@ const mobileMenuGNBCss = (isDropdownOpen: boolean, isPastHero: boolean) => css`
       backdrop-filter: ${isPastHero ? 'blur(10px)' : 'none'};
   `}
 
-  padding: 40px 20px 0 20px;
+  height: 80px;
+  padding: 0 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/features/Main/sections/v18/FeaturesSection.tsx
+++ b/src/features/Main/sections/v18/FeaturesSection.tsx
@@ -39,6 +39,7 @@ const FEATURES: FeatureItem[] = [
 ];
 
 // Calculate track offset to always center the active image
+// Large Desktop (1920px+): container ~1200px (1512 max-width - 156*2 padding), active=600px, inactive=400px, gap=56px
 // Desktop: container ~1200px, active=600px, inactive=400px, gap=56px
 const getTrackOffset = (index: number) => {
   const containerWidth = 1200;
@@ -223,6 +224,11 @@ const contentCss = css`
   @media (min-width: 1280px) {
     padding: 100px 0;
   }
+
+  @media (min-width: 1920px) {
+    max-width: 1512px;
+    padding: 100px 156px;
+  }
 `;
 
 const titleCss = css`
@@ -337,6 +343,11 @@ const infoContainerCss = css`
   @media (min-width: 1280px) {
     /* 데스크탑: (1200 - 600) / 2 = 300px */
     padding-left: 300px;
+  }
+
+  @media (min-width: 1920px) {
+    /* 1920px: 피그마 기준 460px - 156px(padding) = 304px */
+    padding-left: 304px;
   }
 `;
 

--- a/src/features/Main/sections/v18/HeroSection.tsx
+++ b/src/features/Main/sections/v18/HeroSection.tsx
@@ -7,6 +7,20 @@ import useIsInProgress from '~/hooks/useIsInProgress';
 import { colors } from '~/styles/colors';
 import { getPathToRecruit } from '~/utils/utils';
 
+const useIsChrome = () => {
+  const [isChrome, setIsChrome] = useState(false);
+
+  useEffect(() => {
+    const userAgent = navigator.userAgent;
+    // Chrome이지만 Edge, Opera, Samsung Browser 등은 제외
+    const isChromeBrowser =
+      /Chrome/.test(userAgent) && !/Edge|Edg|OPR|Opera|SamsungBrowser/.test(userAgent);
+    setIsChrome(isChromeBrowser);
+  }, []);
+
+  return isChrome;
+};
+
 const CTAButton = () => {
   const [isClientReady, setIsClientReady] = useState(false);
   const router = useRouter();
@@ -28,15 +42,16 @@ const CTAButton = () => {
 
 export const HeroSection = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const isChrome = useIsChrome();
 
   useEffect(() => {
     const video = videoRef.current;
-    if (video) {
+    if (video && isChrome) {
       video.play().catch(() => {
         // Autoplay blocked, will show poster
       });
     }
-  }, []);
+  }, [isChrome]);
 
   return (
     <section css={sectionCss}>
@@ -53,17 +68,28 @@ export const HeroSection = () => {
         </span>
 
         <div css={keyringContainerCss}>
-          <video
-            ref={videoRef}
-            autoPlay
-            loop
-            muted
-            playsInline
-            css={keyringVideoCss}
-            poster="/images/18th/home/keyring.png"
-          >
-            <source src="/images/18th/keyring/keyring.webm" type="video/webm" />
-          </video>
+          {isChrome ? (
+            <video
+              ref={videoRef}
+              autoPlay
+              loop
+              muted
+              playsInline
+              css={keyringVideoCss}
+              poster="/images/18th/home/keyring.png"
+            >
+              <source src="/images/18th/keyring/keyring.webm" type="video/webm" />
+            </video>
+          ) : (
+            <Image
+              src="/images/18th/home/keyring.png"
+              alt="Keyring"
+              width={1215}
+              height={1215}
+              css={keyringVideoCss}
+              priority
+            />
+          )}
         </div>
 
         <div css={logoContainerCss}>

--- a/src/features/Main/sections/v18/HeroSection.tsx
+++ b/src/features/Main/sections/v18/HeroSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
@@ -27,6 +27,17 @@ const CTAButton = () => {
 };
 
 export const HeroSection = () => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (video) {
+      video.play().catch(() => {
+        // Autoplay blocked, will show poster
+      });
+    }
+  }, []);
+
   return (
     <section css={sectionCss}>
       <div css={contentCss}>
@@ -43,6 +54,7 @@ export const HeroSection = () => {
 
         <div css={keyringContainerCss}>
           <video
+            ref={videoRef}
             autoPlay
             loop
             muted

--- a/src/features/Main/sections/v18/StatsSection.tsx
+++ b/src/features/Main/sections/v18/StatsSection.tsx
@@ -196,7 +196,8 @@ const cardCss = css`
   padding: 28px 0;
   gap: 10px;
   border-radius: 12px;
-  background: ${colors.grey18['100']};
+  background: #fff;
+  box-shadow: 0 8px 32px 0 rgba(47, 51, 55, 0.1);
   text-align: center;
 
   @media (min-width: 768px) {
@@ -212,8 +213,6 @@ const cardCss = css`
     padding: 40px 24px;
     gap: 20px;
     flex: 1 0 0;
-    background: #fff;
-    box-shadow: 0 8px 32px 0 rgba(47, 51, 55, 0.1);
   }
 `;
 


### PR DESCRIPTION
## Summary
- GNB 레이아웃 figma 디자인에 맞게 수정
- FeaturesSection 1920px 대형 데스크탑 max-width 1512px 적용
- StatsSection 모든 화면 크기에서 데스크탑 카드 스타일 통일
- HeroSection Chrome만 webm 영상 재생, 그 외 브라우저(Safari, Firefox 등)는 정적 이미지 노출

## Test plan
- [ ] GNB 레이아웃 확인
- [ ] FeaturesSection 1920px 이상 화면에서 max-width 확인
- [ ] StatsSection 카드 스타일 모든 화면 크기에서 확인
- [ ] Chrome에서 keyring 영상 재생 확인
- [ ] Safari/Firefox에서 keyring 이미지 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)