### PR TITLE
fix(v18): 브레이크포인트 v18 표준 통일 및 StatsSection 레이아웃 개선

### DIFF
--- a/src/features/Main/sections/v18/ContactSection.tsx
+++ b/src/features/Main/sections/v18/ContactSection.tsx
@@ -118,11 +118,11 @@ const titleCss = css`
   color: ${colors.grey18['900']};
   margin-bottom: 40px;
 
-  ${mediaQuery('tablet')} {
+  @media (max-width: 1279px) {
     font-size: 28px;
   }
 
-  ${mediaQuery('mobile')} {
+  @media (max-width: 767px) {
     font-size: 20px;
     margin-bottom: 32px;
   }

--- a/src/features/Main/sections/v18/StatsSection.tsx
+++ b/src/features/Main/sections/v18/StatsSection.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import { motion, useInView } from 'framer-motion';
 
 import { colors } from '~/styles/colors';
-import { mediaQuery } from '~/styles/media';
 
 interface StatItem {
   label: string;
@@ -142,7 +141,15 @@ const contentCss = css`
   padding: 120px 40px;
   gap: 40px;
 
-  ${mediaQuery('mobile')} {
+  @media (min-width: 768px) {
+    padding: 120px 46px;
+  }
+
+  @media (min-width: 1280px) {
+    padding: 120px 0;
+  }
+
+  @media (max-width: 767px) {
     padding: 40px 24px;
   }
 `;
@@ -162,7 +169,7 @@ const descriptionCss = css`
     color: ${colors.grey18['900']};
   }
 
-  ${mediaQuery('mobile')} {
+  @media (max-width: 767px) {
     font-size: 16px;
     letter-spacing: normal;
 
@@ -176,20 +183,20 @@ const gridCss = css`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 24px;
+  width: 100%;
 
-  ${mediaQuery('tablet')} {
+  @media (max-width: 1279px) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  ${mediaQuery('mobile')} {
-    grid-template-columns: repeat(2, 1fr);
+  @media (max-width: 767px) {
     gap: 16px;
   }
 `;
 
 const cardCss = css`
   display: flex;
-  width: 152px;
+  width: auto;
   flex-direction: column;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- v18 섹션의 `mediaQuery('tablet')` (1023px)를 v18 표준 `@media (max-width: 1279px)`로 통일
- StatsSection 패딩을 FeaturesSection과 동일하게 조정하여 좌우 정렬
- 카드 너비를 가변으로 변경하여 모바일/태블릿에서도 전체 너비 확장

## Test plan
- [ ] 태블릿(768px-1279px)에서 StatsSection 카드가 FeaturesSection 타이틀과 좌우 정렬 확인
- [ ] 모바일에서 카드가 전체 너비로 확장되는지 확인
- [ ] ContactSection 타이틀 폰트 크기 전환점 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)