### PR TITLE
feat: 18기 홈페이지 디자인 및 기능 개선

### DIFF
--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -123,6 +123,7 @@ const navCommonCss = () => css`
   left: 0;
   z-index: 9998;
   width: 100%;
+  overflow: hidden;
 `;
 
 const navCss = (isPastHero: boolean) => css`

--- a/src/components/GNB/MobileMenuIcon.tsx
+++ b/src/components/GNB/MobileMenuIcon.tsx
@@ -1,110 +1,38 @@
 import { css } from '@emotion/react';
 
-import { colors } from '~/styles/colors';
-
 interface Props {
   onClick?: () => void;
   isChecked?: boolean;
 }
+
+const MenuIcon = ({ color = '#000000' }: { color?: string }) => (
+  <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6 9H26M6 16H26M6 23H26" stroke={color} strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+const CloseIcon = ({ color = '#ffffff' }: { color?: string }) => (
+  <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8 8L24 24M24 8L8 24" stroke={color} strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
 export function MobileMenuIcon({ onClick, isChecked }: Props) {
   return (
-    <div css={containerCss}>
-      <input
-        className="burger-check"
-        type="checkbox"
-        id="burger-check"
-        onClick={onClick}
-        checked={isChecked}
-        readOnly
-      />
-      <label className="burger-icon" htmlFor="burger-check">
-        <span className="burger-sticks"></span>
-      </label>
-    </div>
+    <button css={containerCss} onClick={onClick} aria-label={isChecked ? '메뉴 닫기' : '메뉴 열기'}>
+      {isChecked ? <CloseIcon /> : <MenuIcon />}
+    </button>
   );
 }
 
 const containerCss = css`
-  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 32px;
   height: 32px;
-
-  .menu {
-    position: absolute;
-    top: 0;
-    right: 0;
-    height: 100%;
-    max-width: 0;
-    min-width: 100px;
-    transition: 0.5s ease;
-    z-index: 1;
-    background-color: ${colors.primary.darknavy};
-  }
-
-  .burger-icon {
-    cursor: pointer;
-    display: inline-block;
-    position: absolute;
-    z-index: 2;
-    padding: 8px 0;
-    top: 8px;
-    right: 4px;
-    user-select: none;
-    width: auto;
-
-    .burger-sticks {
-      background: ${colors.primary.darknavy};
-      display: block;
-      height: 3px;
-      position: relative;
-      transition: background 0.2s ease-out;
-      width: 24px;
-
-      &:before,
-      &:after {
-        background: ${colors.primary.darknavy};
-        content: '';
-        display: block;
-        height: 100%;
-        position: absolute;
-        transition: all 0.2s ease-out;
-        width: 100%;
-      }
-
-      &:before {
-        top: 8px;
-      }
-
-      &:after {
-        top: -8px;
-      }
-    }
-  }
-
-  .burger-check {
-    display: none;
-  }
-
-  .burger-check:checked ~ .burger-icon .burger-sticks {
-    background: transparent;
-    left: -5px;
-
-    &:before {
-      background: ${colors.grey[100]};
-      transform: rotate(-45deg);
-      /* left: -5px; */
-    }
-    &:after {
-      background: ${colors.grey[100]};
-      transform: rotate(45deg);
-      /* left: -5px; */
-    }
-  }
-
-  .burger-check:checked ~ .burger-icon:not(.steps) .burger-sticks {
-    &:before,
-    &:after {
-      top: 0;
-    }
-  }
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
 `;

--- a/src/features/Main/sections/v18/SessionsSection.tsx
+++ b/src/features/Main/sections/v18/SessionsSection.tsx
@@ -260,7 +260,7 @@ const desktopLayoutCss = css`
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-    padding: 124px 80px;
+    padding: 124px 40px;
     gap: 80px;
   }
 

--- a/src/styles/globalStyle.tsx
+++ b/src/styles/globalStyle.tsx
@@ -15,6 +15,8 @@ const globalCss = css`
   html,
   body {
     background-color: #5aafff;
+    max-width: 100vw;
+    overflow-x: hidden;
   }
 
   :root {


### PR DESCRIPTION
## Summary
- 18기 홈페이지 전체 디자인 구현 및 개선
- BrandingSection 피그마 디자인 명세 반영 (높이, 그라디언트, 그림자 효과)
- MobileMenuIcon SVG 아이콘으로 교체
- 반응형 레이아웃 및 스타일 QA 수정

## Changes
### 홈페이지 (v18 sections)
- HeroSection, BrandingSection, StatsSection, FeaturesSection 구현
- SessionsSection, ProjectsSection, FAQSection, SponsorsSection 구현
- ContactSection, Footer 디자인 업데이트

### BrandingSection 개선
- 섹션 높이 745px → 1000px
- 그라디언트 시작점 0% → 30% 수정
- 그림자 타원 효과 추가 (opacity 40%)
- 블러 애니메이션 제거

### MobileMenuIcon 개선
- CSS 기반 → SVG 아이콘 교체
- 둥근 끝 처리 (strokeLinecap: round)
- 접근성 aria-label 추가

### 기타
- 320px 뷰포트 가로 스크롤 방지
- 모집 안내 페이지 디자인 QA 수정

## Test plan
- [ ] 데스크탑 (1920px, 1280px) 레이아웃 확인
- [ ] 태블릿 (768px) 레이아웃 확인
- [ ] 모바일 (360px, 320px) 레이아웃 확인
- [ ] 모바일 메뉴 아이콘 동작 확인
- [ ] BrandingSection 스크롤 애니메이션 확인

🤖 Generated with [Claude Code](https://claude.ai/code)