### PR TITLE
fix: 20260202 QA 2차 작업

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -29,9 +29,9 @@ export function Pagination({ handlePageClick, numberOfPages, currentPage }: Pagi
   }, []);
 
   useEffect(() => {
-    if (isMobile && numberOfPages > 3) {
-      const maxVisiblePages = 3;
-      let startPage = Math.max(1, currentPage - 1);
+    if (isMobile && numberOfPages > 4) {
+      const maxVisiblePages = 4;
+      let startPage = Math.max(1, currentPage - 2);
       const endPage = Math.min(numberOfPages, startPage + maxVisiblePages - 1);
 
       if (endPage - startPage + 1 < maxVisiblePages) {
@@ -95,7 +95,7 @@ export function Pagination({ handlePageClick, numberOfPages, currentPage }: Pagi
     }
   };
 
-  const showArrows = isMobile && numberOfPages > 3;
+  const showArrows = isMobile && numberOfPages > 4;
 
   return (
     <div css={[containerCss, isCentered && !showArrows && centeredListCss]} ref={containerRef}>
@@ -187,7 +187,7 @@ const mobileListCss = css`
   @media (max-width: 768px) {
     flex: 1;
     justify-content: center;
-    max-width: 150px;
+    max-width: 224px;
   }
 `;
 

--- a/src/components/Project/ProjectThumbnail.tsx
+++ b/src/components/Project/ProjectThumbnail.tsx
@@ -54,16 +54,18 @@ export function ProjectThumbnail({
           />
           <div css={thumbnailOverlayCss} className="thumbnail-overlay">
             {links && links.length > 0 && (
-              <div css={linksContainerCss(links.length)}>
-                {links.map((link, index) => (
-                  <React.Fragment key={index}>
-                    <button css={linkButtonCss} onClick={e => handleLinkClick(link.href, e)}>
-                      {link.type}
-                      <ArrowIcon direction={'right'} color="white" width={20} height={20} />
-                    </button>
-                    {index < links.length - 1 && <div css={dividerCss}>∙</div>}
-                  </React.Fragment>
-                ))}
+              <div css={overlayInnerCss}>
+                <div css={linksContainerCss(links.length)}>
+                  {links.map((link, index) => (
+                    <React.Fragment key={index}>
+                      <button css={linkButtonCss} onClick={e => handleLinkClick(link.href, e)}>
+                        {link.type}
+                        <ArrowIcon direction={'right'} color="white" width={20} height={20} />
+                      </button>
+                      {index < links.length - 1 && <div css={dividerCss}>∙</div>}
+                    </React.Fragment>
+                  ))}
+                </div>
               </div>
             )}
           </div>
@@ -140,10 +142,19 @@ const thumbnailOverlayCss = css`
   height: 100%;
   background: ${colors.grey18['900']};
   display: flex;
-  align-items: center;
-  justify-content: center;
   opacity: 0;
   transition: opacity 0.3s ease;
+`;
+
+const overlayInnerCss = css`
+  width: 100%;
+  height: 100%;
+  padding: 28px 0;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 `;
 
 const linksContainerCss = (linkCount: number) => css`
@@ -230,7 +241,7 @@ const imageContainerCss = css`
   position: relative;
   width: 100%;
   flex-shrink: 0;
-  aspect-ratio: 16 / 10;
+  height: 283px;
   overflow: hidden;
 `;
 

--- a/src/features/Main/sections/v18/BrandingSection.tsx
+++ b/src/features/Main/sections/v18/BrandingSection.tsx
@@ -15,22 +15,8 @@ const revealVariants = {
   },
 };
 
-const shadowVariants = {
-  hidden: {
-    opacity: 0,
-  },
-  visible: {
-    opacity: 1,
-  },
-};
-
 const enterTransition = {
   duration: 0.9,
-  ease: [0.25, 0.1, 0.25, 1],
-};
-
-const shadowEnterTransition = {
-  duration: 2,
   ease: [0.25, 0.1, 0.25, 1],
 };
 
@@ -81,12 +67,6 @@ export const BrandingSection = () => {
           >
             <p css={subheadingCss}>연결의 가치를 성장의 열쇠로</p>
           </motion.div>
-          <motion.div
-            css={shadowEllipseCss}
-            animate={shouldAnimate ? 'visible' : 'hidden'}
-            variants={shadowVariants}
-            transition={shouldAnimate ? shadowEnterTransition : exitTransition}
-          />
         </div>
       </div>
     </section>
@@ -170,21 +150,5 @@ const subheadingCss = css`
     margin-top: 16px; /* 20px total - 4px gap = 16px */
     font-size: 16px;
     letter-spacing: -0.32px;
-  }
-`;
-
-const shadowEllipseCss = css`
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 924px;
-  height: 104px;
-  background: radial-gradient(50% 50% at 50% 50%, rgba(89, 175, 254, 0.4) 0%, transparent 100%);
-  pointer-events: none;
-
-  @media (max-width: 767px) {
-    width: 462px;
-    height: 52px;
   }
 `;

--- a/src/features/Main/sections/v18/FAQSection.tsx
+++ b/src/features/Main/sections/v18/FAQSection.tsx
@@ -481,6 +481,10 @@ const tabTextCss = (isActive: boolean) => css`
 const faqListCss = css`
   display: flex;
   flex-direction: column;
+
+  ${mediaQuery('mobile')} {
+    margin: 0 20px;
+  }
 `;
 
 const faqItemCss = css`

--- a/src/features/Main/sections/v18/FeaturesSection.tsx
+++ b/src/features/Main/sections/v18/FeaturesSection.tsx
@@ -215,7 +215,7 @@ const sectionCss = css`
 const contentCss = css`
   max-width: 1200px;
   margin: 0 auto;
-  padding: 100px 40px;
+  padding: 100px 40px 114px 40px;
 
   @media (min-width: 768px) {
     padding: 100px 46px;

--- a/src/features/Main/sections/v18/FeaturesSection.tsx
+++ b/src/features/Main/sections/v18/FeaturesSection.tsx
@@ -366,6 +366,7 @@ const textContentCss = css`
   flex-direction: column;
   gap: 16px;
   max-width: 592px;
+  min-height: 143.21px;
 `;
 
 const featureTitleCss = css`
@@ -404,6 +405,7 @@ const navigationCss = css`
   display: flex;
   gap: 20px;
   align-items: center;
+  justify-content: flex-end;
 `;
 
 const navButtonCss = css`

--- a/src/features/Main/sections/v18/SessionsSection.tsx
+++ b/src/features/Main/sections/v18/SessionsSection.tsx
@@ -276,7 +276,6 @@ const leftPanelCss = css`
   flex-direction: column;
   justify-content: space-between;
   height: 669px;
-  padding-left: 24px;
   padding-right: 40px;
 `;
 

--- a/src/features/Main/sections/v18/SessionsSection.tsx
+++ b/src/features/Main/sections/v18/SessionsSection.tsx
@@ -486,6 +486,7 @@ const mobileSessionDescriptionCss = css`
   font-size: 16px;
   font-weight: 500;
   line-height: 1.4;
+  min-height: 89.59px;
   color: ${colors.grey18['900']};
 
   @media (min-width: 768px) {


### PR DESCRIPTION
## 작업 내용

- Pagination 컴포넌트: 모바일에서 페이지네이션 표시 개수를 3개에서 4개로 변경
- ProjectThumbnail 컴포넌트: 프로젝트 썸네일 호버 오버레이에 상하 28px 패딩 추가, 이미지 컨테이너 높이 283px 고정
- BrandingSection: 텍스트 아래 그림자 효과 제거
- FAQSection: FAQ 리스트 컨테이너에 모바일 마진(margin: 0 20px) 추가
- FeaturesSection: 컨텐츠 하단 패딩 수정(padding: 100px 40px 114px 40px), 텍스트 컨텐츠 최소 높이 추가, 네비게이션 정렬 수정
- SessionsSection: 좌측 패널 padding-left 제거, 모바일 설명 텍스트 최소 높이 추가

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
