### PR TITLE
fix: 데스크톱 GNB 선택 메뉴 색 원복, #59aefe는 모바일 메뉴에만 적용

### DIFF
--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -274,7 +274,7 @@ const menuCss = css`
 `;
 
 const activeLinkCss = () => css`
-  color: #59aefe;
+  color: ${colors.grey18['900']};
   font-family: Pretendard, sans-serif;
   font-size: 20px;
   font-style: normal;


### PR DESCRIPTION
## 작업 내용

- 데스크톱 GNB 선택 메뉴 색 원복, #59aefe는 모바일 메뉴에만 적용

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 사용 방법

<!-- common한 module을 개발했을 경우 사용법을 간략하게 적어주세요 -->

## 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
