### PR TITLE
feat(HeroSection): safari 브라우저에서 투명 배경 키링 영상 지원

### DIFF
--- a/src/features/Main/sections/v18/HeroSection.tsx
+++ b/src/features/Main/sections/v18/HeroSection.tsx
@@ -7,18 +7,27 @@ import useIsInProgress from '~/hooks/useIsInProgress';
 import { colors } from '~/styles/colors';
 import { getPathToRecruit } from '~/utils/utils';
 
-const useIsChrome = () => {
-  const [isChrome, setIsChrome] = useState(false);
+const useBrowserType = () => {
+  const [browserType, setBrowserType] = useState<'chrome' | 'safari' | 'other'>('other');
 
   useEffect(() => {
     const userAgent = navigator.userAgent;
     // Chrome이지만 Edge, Opera, Samsung Browser 등은 제외
     const isChromeBrowser =
       /Chrome/.test(userAgent) && !/Edge|Edg|OPR|Opera|SamsungBrowser/.test(userAgent);
-    setIsChrome(isChromeBrowser);
+    // Safari이지만 Chrome이 아닌 경우 (Chrome UA에도 Safari가 포함됨)
+    const isSafariBrowser = /Safari/.test(userAgent) && !/Chrome/.test(userAgent);
+
+    if (isChromeBrowser) {
+      setBrowserType('chrome');
+    } else if (isSafariBrowser) {
+      setBrowserType('safari');
+    } else {
+      setBrowserType('other');
+    }
   }, []);
 
-  return isChrome;
+  return browserType;
 };
 
 const CTAButton = () => {
@@ -42,16 +51,63 @@ const CTAButton = () => {
 
 export const HeroSection = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const isChrome = useIsChrome();
+  const browserType = useBrowserType();
 
   useEffect(() => {
     const video = videoRef.current;
-    if (video && isChrome) {
+    if (video && (browserType === 'chrome' || browserType === 'safari')) {
       video.play().catch(() => {
         // Autoplay blocked, will show poster
       });
     }
-  }, [isChrome]);
+  }, [browserType]);
+
+  const renderKeyring = () => {
+    if (browserType === 'chrome') {
+      return (
+        <video
+          ref={videoRef}
+          autoPlay
+          loop
+          muted
+          playsInline
+          css={keyringVideoCss}
+          poster="/images/18th/home/keyring.png"
+        >
+          <source src="/images/18th/keyring/keyring.webm" type="video/webm" />
+        </video>
+      );
+    }
+
+    if (browserType === 'safari') {
+      // Safari: HEVC with alpha MOV 사용 (투명 배경 지원)
+      return (
+        <video
+          ref={videoRef}
+          autoPlay
+          loop
+          muted
+          playsInline
+          css={keyringVideoCss}
+          poster="/images/18th/home/keyring.png"
+        >
+          <source src="/images/18th/keyring/keyring.mov" type="video/quicktime" />
+        </video>
+      );
+    }
+
+    // 기타 브라우저: 정적 이미지
+    return (
+      <Image
+        src="/images/18th/home/keyring.png"
+        alt="Keyring"
+        width={1215}
+        height={1215}
+        css={keyringVideoCss}
+        priority
+      />
+    );
+  };
 
   return (
     <section css={sectionCss}>
@@ -67,30 +123,7 @@ export const HeroSection = () => {
           KEY
         </span>
 
-        <div css={keyringContainerCss}>
-          {isChrome ? (
-            <video
-              ref={videoRef}
-              autoPlay
-              loop
-              muted
-              playsInline
-              css={keyringVideoCss}
-              poster="/images/18th/home/keyring.png"
-            >
-              <source src="/images/18th/keyring/keyring.webm" type="video/webm" />
-            </video>
-          ) : (
-            <Image
-              src="/images/18th/home/keyring.png"
-              alt="Keyring"
-              width={1215}
-              height={1215}
-              css={keyringVideoCss}
-              priority
-            />
-          )}
-        </div>
+        <div css={keyringContainerCss}>{renderKeyring()}</div>
 
         <div css={logoContainerCss}>
           <Image


### PR DESCRIPTION
## Summary
- Safari 브라우저 감지 로직 추가 (`useBrowserType` 훅)
- Safari에서 HEVC with alpha MOV 영상으로 투명 배경 키링 애니메이션 지원
- Chrome은 기존 WebM, 기타 브라우저는 정적 PNG 이미지 표시

## Test plan
- [ ] Chrome에서 WebM 영상 재생 확인
- [ ] Safari에서 MOV 영상 투명 배경 재생 확인
- [ ] 기타 브라우저에서 정적 이미지 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)